### PR TITLE
Show role-specific TTPB preview table

### DIFF
--- a/app/Http/Controllers/TtpbController.php
+++ b/app/Http/Controllers/TtpbController.php
@@ -92,7 +92,7 @@ class TtpbController extends Controller
                 ->withErrors($e->errors());
         }
 
-        session(['ttpb_preview_ids' => $createdIds]);
+        session(["ttpb_preview_ids_{$role}" => $createdIds]);
 
         return redirect()->route("{$role}.ttpb.preview");
     }

--- a/resources/views/ttpb/preview.blade.php
+++ b/resources/views/ttpb/preview.blade.php
@@ -1,51 +1,61 @@
 @section('title', __('TTPB Preview'))
 <x-layouts.app :title="__('TTPB Preview')">
-<h5 class="mb-4">{{ __('TTPB Preview') }}</h5>
-@forelse ($records->groupBy('no_ttpb') as $noTtpb => $items)
-    @php $first = $items->first(); @endphp
-    <div class="card mb-4">
-        <div class="card-body">
-            <p><strong>{{ __('No. TTPB') }}:</strong> {{ $first->no_ttpb }}</p>
-            <p><strong>{{ __('Tanggal') }}:</strong> {{ $first->tanggal }}</p>
-            <p><strong>{{ __('Dari') }}:</strong> {{ ucfirst($first->dari) }}</p>
-            <p><strong>{{ __('Ke') }}:</strong> {{ ucfirst($first->ke) }}</p>
-            <div class="table-responsive">
-                <table class="table">
-                    <thead>
-                        <tr>
-                            <th>{{ __('No. Lot') }}</th>
-                            <th>{{ __('QTY Awal') }}</th>
-                            <th>{{ __('QTY Aktual') }}</th>
-                            <th>{{ __('Qty Loss Gudang') }}</th>
-                            <th>{{ __('% Loss Gudang') }}</th>
-                            <th>{{ __('Coly') }}</th>
-                            <th>{{ __('Spec') }}</th>
-                            <th>{{ __('Keterangan') }}</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        @foreach ($items as $item)
-                            <tr>
-                                <td>{{ $item->lot_number }}</td>
-                                <td>{{ $item->qty_awal }}</td>
-                                <td>{{ $item->qty_aktual }}</td>
-                                <td>{{ $item->qty_loss }}</td>
-                                <td>{{ $item->persen_loss }}</td>
-                                <td>{{ $item->coly }}</td>
-                                <td>{{ $item->spec }}</td>
-                                <td>{{ $item->keterangan }}</td>
-                            </tr>
-                        @endforeach
-                    </tbody>
-                </table>
-            </div>
-        </div>
+    <h5 class="mb-4">{{ __('TTPB Preview') }}</h5>
+    <div class="table-responsive">
+        <table class="table table-striped table-bordered">
+            <thead>
+                <tr>
+                    <th>No</th>
+                    <th>{{ __('Tanggal') }}</th>
+                    <th>{{ __('No. TTPB') }}</th>
+                    <th>{{ __('Lot Number') }}</th>
+                    <th>{{ __('Nama Barang') }}</th>
+                    <th>{{ __('Dari') }}</th>
+                    <th>{{ __('Ke') }}</th>
+                    <th>{{ __('QTY Awal') }}</th>
+                    <th>{{ __('QTY Aktual') }}</th>
+                    <th>{{ __('Qty Loss Gudang') }}</th>
+                    <th>{{ __('% Loss Gudang') }}</th>
+                    @if ($role === 'pencucian')
+                        <th>{{ __('Kadar Air') }}</th>
+                        <th>{{ __('Deviasi') }}</th>
+                    @endif
+                    <th>{{ __('Coly') }}</th>
+                    <th>{{ __('Spec') }}</th>
+                    <th>{{ __('Keterangan') }}</th>
+                </tr>
+            </thead>
+            <tbody>
+                @forelse ($records as $item)
+                    <tr>
+                        <td>{{ $loop->iteration }}</td>
+                        <td>{{ $item->tanggal }}</td>
+                        <td>{{ $item->no_ttpb }}</td>
+                        <td>{{ $item->lot_number }}</td>
+                        <td>{{ $item->nama_barang }}</td>
+                        <td>{{ ucfirst($item->dari) }}</td>
+                        <td>{{ ucfirst($item->ke) }}</td>
+                        <td>{{ $item->qty_awal }}</td>
+                        <td>{{ $item->qty_aktual }}</td>
+                        <td>{{ $item->qty_loss }}</td>
+                        <td>{{ $item->persen_loss }}</td>
+                        @if ($role === 'pencucian')
+                            <td>{{ $item->kadar_air }}</td>
+                            <td>{{ $item->deviasi }}</td>
+                        @endif
+                        <td>{{ $item->coly }}</td>
+                        <td>{{ $item->spec }}</td>
+                        <td>{{ $item->keterangan }}</td>
+                    </tr>
+                @empty
+                    <tr>
+                        <td colspan="{{ $role === 'pencucian' ? 16 : 14 }}" class="text-center">{{ __('Belum ada data') }}</td>
+                    </tr>
+                @endforelse
+            </tbody>
+        </table>
     </div>
-@empty
-    <div class="card">
-        <div class="card-body text-center">{{ __('Belum ada data') }}</div>
-    </div>
-@endforelse
 
-<a href="{{ route($role.'.ttpb') }}" class="btn btn-primary mt-3">{{ __('Kembali') }}</a>
+    <a href="{{ route($role.'.ttpb') }}" class="btn btn-primary mt-3">{{ __('Kembali') }}</a>
 </x-layouts.app>
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -90,8 +90,10 @@ Route::middleware(['auth'])->group(function () {
     Route::post("{$role}/ttpb", [TtpbController::class, 'store'])->name("{$role}.ttpb.store");
 
     Route::get("{$role}/ttpb/preview", function () use ($role) {
-      $ids = session('ttpb_preview_ids', []);
-      $records = App\Models\Ttpb::whereIn('id', $ids)->get();
+      $ids = session("ttpb_preview_ids_{$role}", []);
+      $records = App\Models\Ttpb::where('dari', $role)
+        ->whereIn('id', $ids)
+        ->get();
       return view('ttpb.preview', ['role' => $role, 'records' => $records]);
     })->name("{$role}.ttpb.preview");
 


### PR DESCRIPTION
## Summary
- Isolate TTPB preview data per role and render dedicated preview table
- Store preview session IDs keyed by role for accurate preview retrieval

## Testing
- `./vendor/bin/pest`


------
https://chatgpt.com/codex/tasks/task_b_6891f40dc2308325bc079c238859800e