### PR TITLE
Use card layout for TTPB preview

### DIFF
--- a/resources/views/ttpb/preview.blade.php
+++ b/resources/views/ttpb/preview.blade.php
@@ -1,26 +1,8 @@
 @section('title', __('TTPB Preview'))
 <x-layouts.app :title="__('TTPB Preview')">
     <style>
-        .ttpb-paper {
-            width: 210mm;
-            min-height: 297mm;
-            margin: 0 auto 2rem;
-            padding: 10mm;
-            background: #fff;
-            border: 1px solid #000;
-        }
-        .ttpb-paper .header p {
-            margin: 0;
-        }
-        .ttpb-paper table {
-            width: 100%;
-            border-collapse: collapse;
-            margin-top: 1rem;
-        }
-        .ttpb-paper th,
-        .ttpb-paper td {
-            border: 1px solid #000;
-            padding: 4px;
+        .ttpb-card th,
+        .ttpb-card td {
             font-size: 0.875rem;
         }
     </style>
@@ -32,44 +14,46 @@
     @endphp
 
     @forelse ($groups as $number => $items)
-        @php
-            $first = $items->first();
-        @endphp
-        <div class="ttpb-paper">
-            <div class="header mb-3">
-                <p>No.TTPB : {{ $number }}</p>
-                <p>Tanggal : {{ $first->tanggal }}</p>
-                <p>Dari : {{ ucfirst($first->dari) }}</p>
-                <p>Ke : {{ ucfirst($first->ke) }}</p>
+        @php $first = $items->first(); @endphp
+        <div class="card mb-4">
+            <div class="card-body ttpb-card">
+                <div class="mb-3">
+                    <p>No.TTPB : {{ $number }}</p>
+                    <p>Tanggal : {{ $first->tanggal }}</p>
+                    <p>Dari : {{ ucfirst($first->dari) }}</p>
+                    <p>Ke : {{ ucfirst($first->ke) }}</p>
+                </div>
+                <div class="table-responsive">
+                    <table class="table table-bordered">
+                        <thead class="table-light">
+                            <tr>
+                                <th>No. Lot</th>
+                                <th>Qty Awal</th>
+                                <th>Qty Aktual</th>
+                                <th>Qty Loss Gudang</th>
+                                <th>% Loss Gudang</th>
+                                <th>Coly</th>
+                                <th>Spec</th>
+                                <th>Keterangan</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach ($items as $item)
+                                <tr>
+                                    <td>{{ $item->lot_number }}</td>
+                                    <td>{{ $item->qty_awal }}</td>
+                                    <td>{{ $item->qty_aktual }}</td>
+                                    <td>{{ $item->qty_loss }}</td>
+                                    <td>{{ $item->persen_loss }}</td>
+                                    <td>{{ $item->coly }}</td>
+                                    <td>{{ $item->spec }}</td>
+                                    <td>{{ $item->keterangan }}</td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
             </div>
-            <table>
-                <thead>
-                    <tr>
-                        <th>No. Lot</th>
-                        <th>Qty Awal</th>
-                        <th>Qty Aktual</th>
-                        <th>Qty Loss Gudang</th>
-                        <th>% Loss Gudang</th>
-                        <th>Coly</th>
-                        <th>Spec</th>
-                        <th>Keterangan</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    @foreach ($items as $item)
-                        <tr>
-                            <td>{{ $item->lot_number }}</td>
-                            <td>{{ $item->qty_awal }}</td>
-                            <td>{{ $item->qty_aktual }}</td>
-                            <td>{{ $item->qty_loss }}</td>
-                            <td>{{ $item->persen_loss }}</td>
-                            <td>{{ $item->coly }}</td>
-                            <td>{{ $item->spec }}</td>
-                            <td>{{ $item->keterangan }}</td>
-                        </tr>
-                    @endforeach
-                </tbody>
-            </table>
         </div>
     @empty
         <p class="text-center">{{ __('Belum ada data') }}</p>


### PR DESCRIPTION
## Summary
- replace custom paper styling with Bootstrap card for TTPB preview
- wrap preview table in responsive bordered table

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_b_6891f89ae8188325aa695a6e057742ec