### PR TITLE
Add loss and actual quantity to BPG

### DIFF
--- a/app/Http/Controllers/BpgController.php
+++ b/app/Http/Controllers/BpgController.php
@@ -16,6 +16,8 @@ class BpgController extends Controller
     {
         $request->merge([
             'qty' => $this->normalizeNumber($request->input('qty')),
+            'qty_aktual' => $this->normalizeNumber($request->input('qty_aktual')),
+            'qty_loss' => $this->normalizeNumber($request->input('qty_loss')),
         ]);
 
         $validated = $request->validate([
@@ -25,10 +27,14 @@ class BpgController extends Controller
             'supplier' => 'required|string',
             'nama_barang' => 'required|string',
             'qty' => 'required|numeric',
+            'qty_aktual' => 'required|numeric',
+            'qty_loss' => 'nullable|numeric',
             'coly' => 'nullable|string',
             'diterima' => 'required|string',
             'ttpb' => 'required|string',
         ]);
+
+        $validated['qty_loss'] = $validated['qty'] - $validated['qty_aktual'];
 
         $bpg->update($validated);
 
@@ -45,6 +51,8 @@ class BpgController extends Controller
     {
         $request->merge([
             'qty' => $this->normalizeNumber($request->input('qty')),
+            'qty_aktual' => $this->normalizeNumber($request->input('qty_aktual')),
+            'qty_loss' => $this->normalizeNumber($request->input('qty_loss')),
         ]);
 
         $validated = $request->validate([
@@ -54,10 +62,14 @@ class BpgController extends Controller
             'supplier' => 'required|string',
             'nama_barang' => 'required|string',
             'qty' => 'required|numeric',
+            'qty_aktual' => 'required|numeric',
+            'qty_loss' => 'nullable|numeric',
             'coly' => 'nullable|string',
             'diterima' => 'required|string',
             'ttpb' => 'required|string',
         ]);
+
+        $validated['qty_loss'] = $validated['qty'] - $validated['qty_aktual'];
 
         Bpg::create($validated);
 

--- a/app/Models/Bpg.php
+++ b/app/Models/Bpg.php
@@ -16,6 +16,8 @@ class Bpg extends Model
         'supplier',
         'nama_barang',
         'qty',
+        'qty_aktual',
+        'qty_loss',
         'coly',
         'diterima',
         'ttpb',
@@ -23,5 +25,7 @@ class Bpg extends Model
 
     protected $casts = [
         'qty' => 'float',
+        'qty_aktual' => 'float',
+        'qty_loss' => 'float',
     ];
 }

--- a/database/factories/BpgFactory.php
+++ b/database/factories/BpgFactory.php
@@ -11,16 +11,31 @@ class BpgFactory extends Factory
 
     public function definition(): array
     {
+        $qty = $this->faker->randomFloat(1, 1, 100);
+        $qtyAktual = $this->faker->randomFloat(1, 0, $qty);
+
         return [
             'tanggal' => now()->toDateString(),
             'no_bpg' => $this->faker->unique()->numerify('BPG-###'),
             'lot_number' => $this->faker->unique()->bothify('LOT-###'),
             'supplier' => $this->faker->company,
             'nama_barang' => $this->faker->word,
-            'qty' => $this->faker->randomFloat(1, 1, 100),
+            'qty' => $qty,
+            'qty_aktual' => $qtyAktual,
+            'qty_loss' => $qty - $qtyAktual,
             'coly' => $this->faker->word,
             'diterima' => $this->faker->name,
             'ttpb' => $this->faker->numerify('TTPB-###'),
         ];
+    }
+
+    public function configure()
+    {
+        return $this->afterMaking(function (Bpg $bpg) {
+            if ($bpg->qty_aktual === null) {
+                $bpg->qty_aktual = $bpg->qty;
+            }
+            $bpg->qty_loss = $bpg->qty - $bpg->qty_aktual;
+        });
     }
 }

--- a/database/migrations/2025_09_01_000000_add_qty_aktual_and_qty_loss_to_bpgs_table.php
+++ b/database/migrations/2025_09_01_000000_add_qty_aktual_and_qty_loss_to_bpgs_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('bpgs', function (Blueprint $table) {
+            $table->double('qty_aktual')->nullable()->after('qty');
+            $table->double('qty_loss')->nullable()->after('qty_aktual');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('bpgs', function (Blueprint $table) {
+            $table->dropColumn(['qty_aktual', 'qty_loss']);
+        });
+    }
+};

--- a/resources/views/bpg/edit.blade.php
+++ b/resources/views/bpg/edit.blade.php
@@ -34,6 +34,14 @@
                         <input type="text" inputmode="decimal" id="qty" name="qty" class="form-control" value="{{ old('qty', $record->qty) }}" />
                     </div>
                     <div class="col-md-6">
+                        <label for="qty_aktual" class="form-label">{{ __('QTY Aktual') }}</label>
+                        <input type="text" inputmode="decimal" id="qty_aktual" name="qty_aktual" class="form-control" value="{{ old('qty_aktual', $record->qty_aktual) }}" />
+                    </div>
+                    <div class="col-md-6">
+                        <label for="qty_loss" class="form-label">{{ __('Loss') }}</label>
+                        <input type="text" inputmode="decimal" id="qty_loss" name="qty_loss" class="form-control" value="{{ old('qty_loss', $record->qty_loss) }}" readonly />
+                    </div>
+                    <div class="col-md-6">
                         <label for="coly" class="form-label">{{ __('Coly') }}</label>
                         <input type="text" id="coly" name="coly" class="form-control" value="{{ old('coly', $record->coly) }}" />
                     </div>
@@ -53,3 +61,16 @@
         </div>
     </div>
 </x-layouts.app>
+
+@section('page-script')
+    <script>
+        function updateLoss() {
+            const qty = parseFloat(document.getElementById('qty').value) || 0;
+            const qtyAktual = parseFloat(document.getElementById('qty_aktual').value) || 0;
+            document.getElementById('qty_loss').value = qty - qtyAktual;
+        }
+
+        document.getElementById('qty').addEventListener('input', updateLoss);
+        document.getElementById('qty_aktual').addEventListener('input', updateLoss);
+    </script>
+@endsection

--- a/resources/views/gudang/partials/stock-form.blade.php
+++ b/resources/views/gudang/partials/stock-form.blade.php
@@ -31,6 +31,14 @@
                     <input type="text" inputmode="decimal" id="qty" name="qty" class="form-control" />
                 </div>
                 <div class="col-md-6">
+                    <label for="qty_aktual" class="form-label">{{ __('QTY Aktual') }}</label>
+                    <input type="text" inputmode="decimal" id="qty_aktual" name="qty_aktual" class="form-control" />
+                </div>
+                <div class="col-md-6">
+                    <label for="qty_loss" class="form-label">{{ __('Loss') }}</label>
+                    <input type="text" inputmode="decimal" id="qty_loss" name="qty_loss" class="form-control" readonly />
+                </div>
+                <div class="col-md-6">
                     <label for="coly" class="form-label">{{ __('Coly') }}</label>
                     <input type="text" id="coly" name="coly" class="form-control" />
                 </div>
@@ -49,3 +57,16 @@
         </form>
     </div>
 </div>
+
+@section('page-script')
+    <script>
+        function updateLoss() {
+            const qty = parseFloat(document.getElementById('qty').value) || 0;
+            const qtyAktual = parseFloat(document.getElementById('qty_aktual').value) || 0;
+            document.getElementById('qty_loss').value = qty - qtyAktual;
+        }
+
+        document.getElementById('qty').addEventListener('input', updateLoss);
+        document.getElementById('qty_aktual').addEventListener('input', updateLoss);
+    </script>
+@endsection

--- a/resources/views/gudang/stock.blade.php
+++ b/resources/views/gudang/stock.blade.php
@@ -18,6 +18,8 @@
                         <th>Supplier</th>
                         <th>Nama Barang</th>
                         <th>QTY (kg)</th>
+                        <th>QTY Aktual</th>
+                        <th>Loss</th>
                         <th>Coly</th>
                         <th>Diterima Oleh</th>
                         <th>TTPB</th>
@@ -33,6 +35,8 @@
                             <td>{{ $item->supplier }}</td>
                             <td>{{ $item->nama_barang }}</td>
                             <td>{{ $item->qty }}</td>
+                            <td>{{ $item->qty_aktual }}</td>
+                            <td>{{ $item->qty_loss }}</td>
                             <td>{{ $item->coly }}</td>
                             <td>{{ $item->diterima }}</td>
                             <td>{{ $item->ttpb }}</td>
@@ -47,7 +51,7 @@
                         </tr>
                     @empty
                         <tr>
-                            <td colspan="9" class="text-center">{{ __('Belum ada data') }}</td>
+                            <td colspan="12" class="text-center">{{ __('Belum ada data') }}</td>
                         </tr>
                     @endforelse
                 </tbody>


### PR DESCRIPTION
## Summary
- track BPG actual quantities and loss with new migration and model fields
- handle qty aktual and loss in BPG controller, forms and stock table with auto-loss calculation

## Testing
- `vendor/bin/pest`

------
https://chatgpt.com/codex/tasks/task_b_689307aefd788325a756ff4d093041de