### PR TITLE
fix: preserve decimal quantities

### DIFF
--- a/app/Http/Controllers/BpgController.php
+++ b/app/Http/Controllers/BpgController.php
@@ -79,8 +79,18 @@ class BpgController extends Controller
     private function normalizeNumber($value)
     {
         if ($value === null) {
-            return $value;
+            return null;
         }
-        return str_replace(',', '.', str_replace('.', '', $value));
+
+        $value = trim($value);
+
+        if (strpos($value, ',') !== false && strpos($value, '.') !== false) {
+            $value = str_replace('.', '', $value);
+            $value = str_replace(',', '.', $value);
+        } else {
+            $value = str_replace(',', '.', $value);
+        }
+
+        return (float) $value;
     }
 }

--- a/app/Http/Controllers/TtpbController.php
+++ b/app/Http/Controllers/TtpbController.php
@@ -130,8 +130,18 @@ class TtpbController extends Controller
     private function normalizeNumber($value)
     {
         if ($value === null) {
-            return $value;
+            return null;
         }
-        return str_replace(',', '.', str_replace('.', '', $value));
+
+        $value = trim($value);
+
+        if (strpos($value, ',') !== false && strpos($value, '.') !== false) {
+            $value = str_replace('.', '', $value);
+            $value = str_replace(',', '.', $value);
+        } else {
+            $value = str_replace(',', '.', $value);
+        }
+
+        return (float) $value;
     }
 }

--- a/resources/views/blower/ttpb-create.blade.php
+++ b/resources/views/blower/ttpb-create.blade.php
@@ -131,7 +131,14 @@
 @section('page-script')
     <script>
         function parseNumber(val) {
-            return parseFloat((val || '').replace(/\./g, '').replace(',', '.')) || 0;
+            val = (val || '').trim();
+            if (!val) return 0;
+            if (val.includes('.') && val.includes(',')) {
+                val = val.replace(/\./g, '').replace(',', '.');
+            } else {
+                val = val.replace(',', '.');
+            }
+            return parseFloat(val) || 0;
         }
 
         document.getElementById('lot_number').addEventListener('change', function () {

--- a/resources/views/grinding/ttpb-create.blade.php
+++ b/resources/views/grinding/ttpb-create.blade.php
@@ -130,7 +130,14 @@
 @section('page-script')
     <script>
         function parseNumber(val) {
-            return parseFloat((val || '').replace(/\./g, '').replace(',', '.')) || 0;
+            val = (val || '').trim();
+            if (!val) return 0;
+            if (val.includes('.') && val.includes(',')) {
+                val = val.replace(/\./g, '').replace(',', '.');
+            } else {
+                val = val.replace(',', '.');
+            }
+            return parseFloat(val) || 0;
         }
 
         document.getElementById('lot_number').addEventListener('change', function () {

--- a/resources/views/mixing/ttpb-create.blade.php
+++ b/resources/views/mixing/ttpb-create.blade.php
@@ -131,7 +131,14 @@
 @section('page-script')
     <script>
         function parseNumber(val) {
-            return parseFloat((val || '').replace(/\./g, '').replace(',', '.')) || 0;
+            val = (val || '').trim();
+            if (!val) return 0;
+            if (val.includes('.') && val.includes(',')) {
+                val = val.replace(/\./g, '').replace(',', '.');
+            } else {
+                val = val.replace(',', '.');
+            }
+            return parseFloat(val) || 0;
         }
 
         document.getElementById('lot_number').addEventListener('change', function () {

--- a/resources/views/pengeringan/ttpb-create.blade.php
+++ b/resources/views/pengeringan/ttpb-create.blade.php
@@ -132,7 +132,14 @@
 @section('page-script')
     <script>
         function parseNumber(val) {
-            return parseFloat((val || '').replace(/\./g, '').replace(',', '.')) || 0;
+            val = (val || '').trim();
+            if (!val) return 0;
+            if (val.includes('.') && val.includes(',')) {
+                val = val.replace(/\./g, '').replace(',', '.');
+            } else {
+                val = val.replace(',', '.');
+            }
+            return parseFloat(val) || 0;
         }
 
         document.getElementById('lot_number').addEventListener('change', function () {

--- a/resources/views/ttpb/create.blade.php
+++ b/resources/views/ttpb/create.blade.php
@@ -145,7 +145,14 @@ document.addEventListener('DOMContentLoaded', function () {
     const stickyFields = ['tanggal', 'no_ttpb', 'dari', 'ke'];
 
     function parseNumber(val) {
-        return parseFloat((val || '').replace(/\./g, '').replace(',', '.')) || 0;
+        val = (val || '').trim();
+        if (!val) return 0;
+        if (val.includes('.') && val.includes(',')) {
+            val = val.replace(/\./g, '').replace(',', '.');
+        } else {
+            val = val.replace(',', '.');
+        }
+        return parseFloat(val) || 0;
     }
 
     const currentRow = template.cloneNode(true);


### PR DESCRIPTION
## Summary
- avoid stripping decimal separator when normalizing quantity numbers
- handle both `,` and `.` decimal separators in TTPB create forms

## Testing
- `vendor/bin/pest`


------
https://chatgpt.com/codex/tasks/task_b_689311656f848325874a7138fde01703