### PR TITLE
Fix TTPB store for single form submissions

### DIFF
--- a/app/Http/Controllers/TtpbController.php
+++ b/app/Http/Controllers/TtpbController.php
@@ -55,6 +55,31 @@ class TtpbController extends Controller
     }
     public function store(Request $request)
     {
+        // Support forms that submit a single record without wrapping fields in an
+        // `items` array. When the request doesn't contain an `items` key we
+        // assume all top level fields represent a single entry and wrap them
+        // accordingly so the rest of the method can handle them uniformly.
+        if (!$request->has('items')) {
+            $single = $request->only([
+                'tanggal',
+                'no_ttpb',
+                'lot_number',
+                'nama_barang',
+                'qty_awal',
+                'qty_aktual',
+                'qty_loss',
+                'persen_loss',
+                'kadar_air',
+                'deviasi',
+                'coly',
+                'spec',
+                'keterangan',
+                'ke',
+                'dari',
+            ]);
+            $request->merge(['items' => [$single]]);
+        }
+
         $items = collect($request->input('items', []))->map(function ($item) {
             $item['qty_awal'] = $this->normalizeNumber($item['qty_awal'] ?? null);
             $item['qty_aktual'] = $this->normalizeNumber($item['qty_aktual'] ?? null);

--- a/tests/Feature/TtpbStoreTest.php
+++ b/tests/Feature/TtpbStoreTest.php
@@ -148,6 +148,43 @@ test('store ttpb saves all rows including added ones', function () {
     ]);
 });
 
+test('store ttpb handles single item input without array', function () {
+    $user = User::factory()->create(['role' => 'gudang']);
+    $this->actingAs($user);
+
+    \App\Models\Bpg::factory()->create([
+        'lot_number' => 'LOT-S',
+        'qty' => 30,
+        'nama_barang' => 'Barang',
+        'supplier' => 'Supp',
+    ]);
+
+    $payload = [
+        'tanggal' => '2024-02-01',
+        'no_ttpb' => 'TTPB-020',
+        'lot_number' => 'LOT-S',
+        'nama_barang' => 'Barang',
+        'qty_awal' => 10,
+        'qty_aktual' => 9,
+        'qty_loss' => 1,
+        'persen_loss' => 10,
+        'coly' => 'A',
+        'spec' => 'Spec',
+        'keterangan' => 'Test',
+        'dari' => 'gudang',
+        'ke' => 'pencucian',
+    ];
+
+    $this->post('/gudang/ttpb', $payload)->assertRedirect('/gudang/ttpb/preview');
+
+    $this->assertDatabaseHas('ttpbs', [
+        'no_ttpb' => 'TTPB-020',
+        'lot_number' => 'LOT-S',
+        'qty_awal' => 10,
+        'qty_aktual' => 9,
+    ]);
+});
+
 test('new record is created when the same lot number is sent again', function () {
     $user = User::factory()->create(['role' => 'gudang']);
     $this->actingAs($user);


### PR DESCRIPTION
## Summary
- allow TTPB controller to handle single-item form submissions
- cover single-item submission with test

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_b_68935821902883259dafe3843e1fcdd3