### PR TITLE
Enable searchable Lot Number fields

### DIFF
--- a/resources/views/blower/ttpb-create.blade.php
+++ b/resources/views/blower/ttpb-create.blade.php
@@ -11,6 +11,11 @@
         @endif
         <form method="POST" action="{{ route($role.'.ttpb.store') }}">
             @csrf
+            <datalist id="lot_numbers">
+                @foreach($stocks as $item)
+                    <option value="{{ $item->lot_number }}" data-nama-barang="{{ $item->nama_barang }}"></option>
+                @endforeach
+            </datalist>
             <div class="row g-4">
                 <div class="col-md-6">
                     <label for="tanggal" class="form-label">{{ __('Tanggal') }}</label>
@@ -22,12 +27,7 @@
                 </div>
                 <div class="col-md-6">
                     <label for="lot_number" class="form-label">{{ __('Lot Number') }}</label>
-                    <select id="lot_number" name="lot_number" class="form-select">
-                        <option value="">-- Pilih Lot Number --</option>
-                        @foreach($stocks as $item)
-                            <option value="{{ $item->lot_number }}" data-nama-barang="{{ $item->nama_barang }}">{{ $item->lot_number }}</option>
-                        @endforeach
-                    </select>
+                    <input list="lot_numbers" id="lot_number" name="lot_number" class="form-control" placeholder="-- Pilih Lot Number --" />
                 </div>
                 <div class="col-md-6">
                     <label for="nama_barang" class="form-label">{{ __('Nama Barang') }}</label>
@@ -64,14 +64,9 @@
                 </div>
                 <div id="mix-details" style="display: none;" class="row g-4">
                     <div class="col-md-6">
-                        <label for="lot_number_mix" class="form-label">{{ __('Lot Number Mix') }}</label>
-                        <select id="lot_number_mix" name="lot_number_mix" class="form-select">
-                            <option value="">-- Pilih Lot Number --</option>
-                            @foreach($stocks as $item)
-                                <option value="{{ $item->lot_number }}">{{ $item->lot_number }}</option>
-                            @endforeach
-                        </select>
-                    </div>
+                    <label for="lot_number_mix" class="form-label">{{ __('Lot Number Mix') }}</label>
+                    <input list="lot_numbers" id="lot_number_mix" name="lot_number_mix" class="form-control" placeholder="-- Pilih Lot Number --" />
+                </div>
                     <div class="col-md-6">
                         <label for="qty_awal_mix" class="form-label">{{ __('QTY Awal Mix') }}</label>
                         <input type="text" inputmode="decimal" id="qty_awal_mix" name="qty_awal_mix" class="form-control" />
@@ -141,9 +136,9 @@
             return parseFloat(val) || 0;
         }
 
-        document.getElementById('lot_number').addEventListener('change', function () {
-            const option = this.options[this.selectedIndex];
-            document.getElementById('nama_barang').value = option.dataset.namaBarang || '';
+        document.getElementById('lot_number').addEventListener('input', function () {
+            const option = document.querySelector(`#lot_numbers option[value="${this.value}"]`);
+            document.getElementById('nama_barang').value = option ? option.dataset.namaBarang || '' : '';
         });
 
         function updateLoss() {
@@ -187,8 +182,8 @@
         document.getElementById('qty_aktual').addEventListener('input', updateLoss);
         document.getElementById('ke').addEventListener('change', toggleMixOption);
         document.getElementById('di_mix').addEventListener('change', toggleMixDetails);
-        document.getElementById('lot_number').addEventListener('change', updateMixName);
-        document.getElementById('lot_number_mix').addEventListener('change', updateMixName);
+        document.getElementById('lot_number').addEventListener('input', updateMixName);
+        document.getElementById('lot_number_mix').addEventListener('input', updateMixName);
         toggleMixOption();
         toggleMixDetails();
     </script>

--- a/resources/views/finish_good/ttpb-create.blade.php
+++ b/resources/views/finish_good/ttpb-create.blade.php
@@ -11,6 +11,11 @@
         @endif
         <form method="POST" action="{{ route($role.'.ttpb.store') }}">
             @csrf
+            <datalist id="lot_numbers">
+                @foreach($stocks as $item)
+                    <option value="{{ $item->lot_number }}" data-nama-barang="{{ $item->nama_barang }}"></option>
+                @endforeach
+            </datalist>
             <div class="row g-4">
                 <div class="col-md-6">
                     <label for="tanggal" class="form-label">{{ __('Tanggal') }}</label>
@@ -22,12 +27,7 @@
                 </div>
                 <div class="col-md-6">
                     <label for="lot_number" class="form-label">{{ __('Lot Number') }}</label>
-                    <select id="lot_number" name="lot_number" class="form-select">
-                        <option value="">-- Pilih Lot Number --</option>
-                        @foreach($stocks as $item)
-                            <option value="{{ $item->lot_number }}" data-nama-barang="{{ $item->nama_barang }}">{{ $item->lot_number }}</option>
-                        @endforeach
-                    </select>
+                    <input list="lot_numbers" id="lot_number" name="lot_number" class="form-control" placeholder="-- Pilih Lot Number --" />
                 </div>
                 <div class="col-md-6">
                     <label for="nama_barang" class="form-label">{{ __('Nama Barang') }}</label>
@@ -64,14 +64,9 @@
                 </div>
                 <div id="mix-details" style="display: none;" class="row g-4">
                     <div class="col-md-6">
-                        <label for="lot_number_mix" class="form-label">{{ __('Lot Number Mix') }}</label>
-                        <select id="lot_number_mix" name="lot_number_mix" class="form-select">
-                            <option value="">-- Pilih Lot Number --</option>
-                            @foreach($stocks as $item)
-                                <option value="{{ $item->lot_number }}">{{ $item->lot_number }}</option>
-                            @endforeach
-                        </select>
-                    </div>
+                    <label for="lot_number_mix" class="form-label">{{ __('Lot Number Mix') }}</label>
+                    <input list="lot_numbers" id="lot_number_mix" name="lot_number_mix" class="form-control" placeholder="-- Pilih Lot Number --" />
+                </div>
                     <div class="col-md-6">
                         <label for="qty_awal_mix" class="form-label">{{ __('QTY Awal Mix') }}</label>
                         <input type="number" id="qty_awal_mix" name="qty_awal_mix" class="form-control" />
@@ -130,9 +125,9 @@
 </div>
 @section('page-script')
     <script>
-        document.getElementById('lot_number').addEventListener('change', function () {
-            const option = this.options[this.selectedIndex];
-            document.getElementById('nama_barang').value = option.dataset.namaBarang || '';
+        document.getElementById('lot_number').addEventListener('input', function () {
+            const option = document.querySelector(`#lot_numbers option[value="${this.value}"]`);
+            document.getElementById('nama_barang').value = option ? option.dataset.namaBarang || '' : '';
         });
 
         function updateLoss() {
@@ -176,8 +171,8 @@
         document.getElementById('qty_aktual').addEventListener('input', updateLoss);
         document.getElementById('ke').addEventListener('change', toggleMixOption);
         document.getElementById('di_mix').addEventListener('change', toggleMixDetails);
-        document.getElementById('lot_number').addEventListener('change', updateMixName);
-        document.getElementById('lot_number_mix').addEventListener('change', updateMixName);
+        document.getElementById('lot_number').addEventListener('input', updateMixName);
+        document.getElementById('lot_number_mix').addEventListener('input', updateMixName);
         toggleMixOption();
         toggleMixDetails();
     </script>

--- a/resources/views/grinding/ttpb-create.blade.php
+++ b/resources/views/grinding/ttpb-create.blade.php
@@ -11,6 +11,11 @@
         @endif
         <form method="POST" action="{{ route($role.'.ttpb.store') }}">
             @csrf
+            <datalist id="lot_numbers">
+                @foreach($stocks as $item)
+                    <option value="{{ $item->lot_number }}" data-nama-barang="{{ $item->nama_barang }}"></option>
+                @endforeach
+            </datalist>
             <div class="row g-4">
                 <div class="col-md-6">
                     <label for="tanggal" class="form-label">{{ __('Tanggal') }}</label>
@@ -22,12 +27,7 @@
                 </div>
                 <div class="col-md-6">
                     <label for="lot_number" class="form-label">{{ __('Lot Number') }}</label>
-                    <select id="lot_number" name="lot_number" class="form-select">
-                        <option value="">-- Pilih Lot Number --</option>
-                        @foreach($stocks as $item)
-                            <option value="{{ $item->lot_number }}" data-nama-barang="{{ $item->nama_barang }}">{{ $item->lot_number }}</option>
-                        @endforeach
-                    </select>
+                    <input list="lot_numbers" id="lot_number" name="lot_number" class="form-control" placeholder="-- Pilih Lot Number --" />
                 </div>
                 <div class="col-md-6">
                     <label for="nama_barang" class="form-label">{{ __('Nama Barang') }}</label>
@@ -63,14 +63,9 @@
                 </div>
                 <div id="mix-details" style="display: none;" class="row g-4">
                     <div class="col-md-6">
-                        <label for="lot_number_mix" class="form-label">{{ __('Lot Number Mix') }}</label>
-                        <select id="lot_number_mix" name="lot_number_mix" class="form-select">
-                            <option value="">-- Pilih Lot Number --</option>
-                            @foreach($stocks as $item)
-                                <option value="{{ $item->lot_number }}">{{ $item->lot_number }}</option>
-                            @endforeach
-                        </select>
-                    </div>
+                    <label for="lot_number_mix" class="form-label">{{ __('Lot Number Mix') }}</label>
+                    <input list="lot_numbers" id="lot_number_mix" name="lot_number_mix" class="form-control" placeholder="-- Pilih Lot Number --" />
+                </div>
                     <div class="col-md-6">
                         <label for="qty_awal_mix" class="form-label">{{ __('QTY Awal Mix') }}</label>
                         <input type="text" inputmode="decimal" id="qty_awal_mix" name="qty_awal_mix" class="form-control" />
@@ -140,9 +135,9 @@
             return parseFloat(val) || 0;
         }
 
-        document.getElementById('lot_number').addEventListener('change', function () {
-            const option = this.options[this.selectedIndex];
-            document.getElementById('nama_barang').value = option.dataset.namaBarang || '';
+        document.getElementById('lot_number').addEventListener('input', function () {
+            const option = document.querySelector(`#lot_numbers option[value="${this.value}"]`);
+            document.getElementById('nama_barang').value = option ? option.dataset.namaBarang || '' : '';
         });
 
         function updateLoss() {
@@ -186,8 +181,8 @@
         document.getElementById('qty_aktual').addEventListener('input', updateLoss);
         document.getElementById('ke').addEventListener('change', toggleMixOption);
         document.getElementById('di_mix').addEventListener('change', toggleMixDetails);
-        document.getElementById('lot_number').addEventListener('change', updateMixName);
-        document.getElementById('lot_number_mix').addEventListener('change', updateMixName);
+        document.getElementById('lot_number').addEventListener('input', updateMixName);
+        document.getElementById('lot_number_mix').addEventListener('input', updateMixName);
         toggleMixOption();
         toggleMixDetails();
     </script>

--- a/resources/views/gudang/ttpb-create.blade.php
+++ b/resources/views/gudang/ttpb-create.blade.php
@@ -11,6 +11,11 @@
         @endif
         <form method="POST" action="{{ route($role.'.ttpb.store') }}">
             @csrf
+            <datalist id="lot_numbers">
+                @foreach($stocks as $item)
+                    <option value="{{ $item->lot_number }}" data-nama-barang="{{ $item->nama_barang }}"></option>
+                @endforeach
+            </datalist>
             <div class="row g-4">
                 
                 <div class="col-md-6">
@@ -23,12 +28,7 @@
                 </div>
                 <div class="col-md-6">
                     <label for="lot_number" class="form-label">{{ __('Lot Number') }}</label>
-                    <select id="lot_number" name="lot_number" class="form-select">
-                        <option value="">-- Pilih Lot Number --</option>
-                        @foreach($stocks as $item)
-                            <option value="{{ $item->lot_number }}" data-nama-barang="{{ $item->nama_barang }}">{{ $item->lot_number }}</option>
-                        @endforeach
-                    </select>
+                    <input list="lot_numbers" id="lot_number" name="lot_number" class="form-control" placeholder="-- Pilih Lot Number --" />
                 </div>
                 <div class="col-md-6">
                     <label for="nama_barang" class="form-label">{{ __('Nama Barang') }}</label>
@@ -64,14 +64,9 @@
                 </div>
                 <div id="mix-details" style="display: none;" class="row g-4">
                     <div class="col-md-6">
-                        <label for="lot_number_mix" class="form-label">{{ __('Lot Number Mix') }}</label>
-                        <select id="lot_number_mix" name="lot_number_mix" class="form-select">
-                            <option value="">-- Pilih Lot Number --</option>
-                            @foreach($stocks as $item)
-                                <option value="{{ $item->lot_number }}">{{ $item->lot_number }}</option>
-                            @endforeach
-                        </select>
-                    </div>
+                    <label for="lot_number_mix" class="form-label">{{ __('Lot Number Mix') }}</label>
+                    <input list="lot_numbers" id="lot_number_mix" name="lot_number_mix" class="form-control" placeholder="-- Pilih Lot Number --" />
+                </div>
                     <div class="col-md-6">
                         <label for="qty_awal_mix" class="form-label">{{ __('QTY Awal Mix') }}</label>
                         <input type="number" id="qty_awal_mix" name="qty_awal_mix" class="form-control" />
@@ -130,9 +125,9 @@
 </div>
 @section('page-script')
     <script>
-        document.getElementById('lot_number').addEventListener('change', function () {
-            const option = this.options[this.selectedIndex];
-            document.getElementById('nama_barang').value = option.dataset.namaBarang || '';
+        document.getElementById('lot_number').addEventListener('input', function () {
+            const option = document.querySelector(`#lot_numbers option[value="${this.value}"]`);
+            document.getElementById('nama_barang').value = option ? option.dataset.namaBarang || '' : '';
         });
 
         function updateLoss() {
@@ -176,8 +171,8 @@
         document.getElementById('qty_aktual').addEventListener('input', updateLoss);
         document.getElementById('ke').addEventListener('change', toggleMixOption);
         document.getElementById('di_mix').addEventListener('change', toggleMixDetails);
-        document.getElementById('lot_number').addEventListener('change', updateMixName);
-        document.getElementById('lot_number_mix').addEventListener('change', updateMixName);
+        document.getElementById('lot_number').addEventListener('input', updateMixName);
+        document.getElementById('lot_number_mix').addEventListener('input', updateMixName);
         toggleMixOption();
         toggleMixDetails();
     </script>

--- a/resources/views/mixing/ttpb-create.blade.php
+++ b/resources/views/mixing/ttpb-create.blade.php
@@ -11,6 +11,11 @@
         @endif
         <form method="POST" action="{{ route($role.'.ttpb.store') }}">
             @csrf
+            <datalist id="lot_numbers">
+                @foreach($stocks as $item)
+                    <option value="{{ $item->lot_number }}" data-nama-barang="{{ $item->nama_barang }}"></option>
+                @endforeach
+            </datalist>
             <div class="row g-4">
                 <div class="col-md-6">
                     <label for="tanggal" class="form-label">{{ __('Tanggal') }}</label>
@@ -22,12 +27,7 @@
                 </div>
                 <div class="col-md-6">
                     <label for="lot_number" class="form-label">{{ __('Lot Number') }}</label>
-                    <select id="lot_number" name="lot_number" class="form-select">
-                        <option value="">-- Pilih Lot Number --</option>
-                        @foreach($stocks as $item)
-                            <option value="{{ $item->lot_number }}" data-nama-barang="{{ $item->nama_barang }}">{{ $item->lot_number }}</option>
-                        @endforeach
-                    </select>
+                    <input list="lot_numbers" id="lot_number" name="lot_number" class="form-control" placeholder="-- Pilih Lot Number --" />
                 </div>
                 <div class="col-md-6">
                     <label for="nama_barang" class="form-label">{{ __('Nama Barang') }}</label>
@@ -64,14 +64,9 @@
                 </div>
                 <div id="mix-details" style="display: none;" class="row g-4">
                     <div class="col-md-6">
-                        <label for="lot_number_mix" class="form-label">{{ __('Lot Number Mix') }}</label>
-                        <select id="lot_number_mix" name="lot_number_mix" class="form-select">
-                            <option value="">-- Pilih Lot Number --</option>
-                            @foreach($stocks as $item)
-                                <option value="{{ $item->lot_number }}">{{ $item->lot_number }}</option>
-                            @endforeach
-                        </select>
-                    </div>
+                    <label for="lot_number_mix" class="form-label">{{ __('Lot Number Mix') }}</label>
+                    <input list="lot_numbers" id="lot_number_mix" name="lot_number_mix" class="form-control" placeholder="-- Pilih Lot Number --" />
+                </div>
                     <div class="col-md-6">
                         <label for="qty_awal_mix" class="form-label">{{ __('QTY Awal Mix') }}</label>
                         <input type="text" inputmode="decimal" id="qty_awal_mix" name="qty_awal_mix" class="form-control" />
@@ -141,9 +136,9 @@
             return parseFloat(val) || 0;
         }
 
-        document.getElementById('lot_number').addEventListener('change', function () {
-            const option = this.options[this.selectedIndex];
-            document.getElementById('nama_barang').value = option.dataset.namaBarang || '';
+        document.getElementById('lot_number').addEventListener('input', function () {
+            const option = document.querySelector(`#lot_numbers option[value="${this.value}"]`);
+            document.getElementById('nama_barang').value = option ? option.dataset.namaBarang || '' : '';
         });
 
         function updateLoss() {
@@ -187,8 +182,8 @@
         document.getElementById('qty_aktual').addEventListener('input', updateLoss);
         document.getElementById('ke').addEventListener('change', toggleMixOption);
         document.getElementById('di_mix').addEventListener('change', toggleMixDetails);
-        document.getElementById('lot_number').addEventListener('change', updateMixName);
-        document.getElementById('lot_number_mix').addEventListener('change', updateMixName);
+        document.getElementById('lot_number').addEventListener('input', updateMixName);
+        document.getElementById('lot_number_mix').addEventListener('input', updateMixName);
         toggleMixOption();
         toggleMixDetails();
     </script>

--- a/resources/views/packaging/ttpb-create.blade.php
+++ b/resources/views/packaging/ttpb-create.blade.php
@@ -11,6 +11,11 @@
         @endif
         <form method="POST" action="{{ route($role.'.ttpb.store') }}">
             @csrf
+            <datalist id="lot_numbers">
+                @foreach($stocks as $item)
+                    <option value="{{ $item->lot_number }}" data-nama-barang="{{ $item->nama_barang }}"></option>
+                @endforeach
+            </datalist>
             <div class="row g-4">
                 <div class="col-md-6">
                     <label for="tanggal" class="form-label">{{ __('Tanggal') }}</label>
@@ -22,12 +27,7 @@
                 </div>
                 <div class="col-md-6">
                     <label for="lot_number" class="form-label">{{ __('Lot Number') }}</label>
-                    <select id="lot_number" name="lot_number" class="form-select">
-                        <option value="">-- Pilih Lot Number --</option>
-                        @foreach($stocks as $item)
-                            <option value="{{ $item->lot_number }}" data-nama-barang="{{ $item->nama_barang }}">{{ $item->lot_number }}</option>
-                        @endforeach
-                    </select>
+                    <input list="lot_numbers" id="lot_number" name="lot_number" class="form-control" placeholder="-- Pilih Lot Number --" />
                 </div>
                 <div class="col-md-6">
                     <label for="nama_barang" class="form-label">{{ __('Nama Barang') }}</label>
@@ -64,14 +64,9 @@
                 </div>
                 <div id="mix-details" style="display: none;" class="row g-4">
                     <div class="col-md-6">
-                        <label for="lot_number_mix" class="form-label">{{ __('Lot Number Mix') }}</label>
-                        <select id="lot_number_mix" name="lot_number_mix" class="form-select">
-                            <option value="">-- Pilih Lot Number --</option>
-                            @foreach($stocks as $item)
-                                <option value="{{ $item->lot_number }}">{{ $item->lot_number }}</option>
-                            @endforeach
-                        </select>
-                    </div>
+                    <label for="lot_number_mix" class="form-label">{{ __('Lot Number Mix') }}</label>
+                    <input list="lot_numbers" id="lot_number_mix" name="lot_number_mix" class="form-control" placeholder="-- Pilih Lot Number --" />
+                </div>
                     <div class="col-md-6">
                         <label for="qty_awal_mix" class="form-label">{{ __('QTY Awal Mix') }}</label>
                         <input type="number" id="qty_awal_mix" name="qty_awal_mix" class="form-control" />
@@ -130,9 +125,9 @@
 </div>
 @section('page-script')
     <script>
-        document.getElementById('lot_number').addEventListener('change', function () {
-            const option = this.options[this.selectedIndex];
-            document.getElementById('nama_barang').value = option.dataset.namaBarang || '';
+        document.getElementById('lot_number').addEventListener('input', function () {
+            const option = document.querySelector(`#lot_numbers option[value="${this.value}"]`);
+            document.getElementById('nama_barang').value = option ? option.dataset.namaBarang || '' : '';
         });
 
         function updateLoss() {
@@ -176,8 +171,8 @@
         document.getElementById('qty_aktual').addEventListener('input', updateLoss);
         document.getElementById('ke').addEventListener('change', toggleMixOption);
         document.getElementById('di_mix').addEventListener('change', toggleMixDetails);
-        document.getElementById('lot_number').addEventListener('change', updateMixName);
-        document.getElementById('lot_number_mix').addEventListener('change', updateMixName);
+        document.getElementById('lot_number').addEventListener('input', updateMixName);
+        document.getElementById('lot_number_mix').addEventListener('input', updateMixName);
         toggleMixOption();
         toggleMixDetails();
     </script>

--- a/resources/views/pencucian/ttpb-create.blade.php
+++ b/resources/views/pencucian/ttpb-create.blade.php
@@ -12,6 +12,11 @@
         @endif
         <form method="POST" action="{{ route($role.'.ttpb.store') }}">
             @csrf
+            <datalist id="lot_numbers">
+                @foreach($stocks as $item)
+                    <option value="{{ $item->lot_number }}" data-nama-barang="{{ $item->nama_barang }}"></option>
+                @endforeach
+            </datalist>
             <div class="row g-4">
                 <div class="col-md-6">
                     <label for="tanggal" class="form-label">{{ __('Tanggal') }}</label>
@@ -23,12 +28,7 @@
                 </div>
                 <div class="col-md-6">
                     <label for="lot_number" class="form-label">{{ __('Lot Number') }}</label>
-                    <select id="lot_number" name="lot_number" class="form-select">
-                        <option value="">-- Pilih Lot Number --</option>
-                        @foreach($stocks as $item)
-                            <option value="{{ $item->lot_number }}" data-nama-barang="{{ $item->nama_barang }}">{{ $item->lot_number }}</option>
-                        @endforeach
-                    </select>
+                    <input list="lot_numbers" id="lot_number" name="lot_number" class="form-control" placeholder="-- Pilih Lot Number --" />
                 </div>
                 <div class="col-md-6">
                     <label for="nama_barang" class="form-label">{{ __('Nama Barang') }}</label>
@@ -65,14 +65,9 @@
                 </div>
                 <div id="mix-details" style="display: none;" class="row g-4">
                     <div class="col-md-6">
-                        <label for="lot_number_mix" class="form-label">{{ __('Lot Number Mix') }}</label>
-                        <select id="lot_number_mix" name="lot_number_mix" class="form-select">
-                            <option value="">-- Pilih Lot Number --</option>
-                            @foreach($stocks as $item)
-                                <option value="{{ $item->lot_number }}">{{ $item->lot_number }}</option>
-                            @endforeach
-                        </select>
-                    </div>
+                    <label for="lot_number_mix" class="form-label">{{ __('Lot Number Mix') }}</label>
+                    <input list="lot_numbers" id="lot_number_mix" name="lot_number_mix" class="form-control" placeholder="-- Pilih Lot Number --" />
+                </div>
                     <div class="col-md-6">
                         <label for="qty_awal_mix" class="form-label">{{ __('QTY Awal Mix') }}</label>
                         <input type="number" id="qty_awal_mix" name="qty_awal_mix" class="form-control" />
@@ -139,9 +134,9 @@
 </div>
 @section('page-script')
     <script>
-        document.getElementById('lot_number').addEventListener('change', function () {
-            const option = this.options[this.selectedIndex];
-            document.getElementById('nama_barang').value = option.dataset.namaBarang || '';
+        document.getElementById('lot_number').addEventListener('input', function () {
+            const option = document.querySelector(`#lot_numbers option[value="${this.value}"]`);
+            document.getElementById('nama_barang').value = option ? option.dataset.namaBarang || '' : '';
         });
 
         function updateLoss() {
@@ -185,8 +180,8 @@
         document.getElementById('qty_aktual').addEventListener('input', updateLoss);
         document.getElementById('ke').addEventListener('change', toggleMixOption);
         document.getElementById('di_mix').addEventListener('change', toggleMixDetails);
-        document.getElementById('lot_number').addEventListener('change', updateMixName);
-        document.getElementById('lot_number_mix').addEventListener('change', updateMixName);
+        document.getElementById('lot_number').addEventListener('input', updateMixName);
+        document.getElementById('lot_number_mix').addEventListener('input', updateMixName);
         toggleMixOption();
         toggleMixDetails();
     </script>

--- a/resources/views/pengeringan/ttpb-create.blade.php
+++ b/resources/views/pengeringan/ttpb-create.blade.php
@@ -12,6 +12,11 @@
         @endif
         <form method="POST" action="{{ route($role.'.ttpb.store') }}">
             @csrf
+            <datalist id="lot_numbers">
+                @foreach($stocks as $item)
+                    <option value="{{ $item->lot_number }}" data-nama-barang="{{ $item->nama_barang }}"></option>
+                @endforeach
+            </datalist>
             <div class="row g-4">
                 <div class="col-md-6">
                     <label for="tanggal" class="form-label">{{ __('Tanggal') }}</label>
@@ -23,12 +28,7 @@
                 </div>
                 <div class="col-md-6">
                     <label for="lot_number" class="form-label">{{ __('Lot Number') }}</label>
-                    <select id="lot_number" name="lot_number" class="form-select">
-                        <option value="">-- Pilih Lot Number --</option>
-                        @foreach($stocks as $item)
-                            <option value="{{ $item->lot_number }}" data-nama-barang="{{ $item->nama_barang }}">{{ $item->lot_number }}</option>
-                        @endforeach
-                    </select>
+                    <input list="lot_numbers" id="lot_number" name="lot_number" class="form-control" placeholder="-- Pilih Lot Number --" />
                 </div>
                 <div class="col-md-6">
                     <label for="nama_barang" class="form-label">{{ __('Nama Barang') }}</label>
@@ -65,14 +65,9 @@
                 </div>
                 <div id="mix-details" style="display: none;" class="row g-4">
                     <div class="col-md-6">
-                        <label for="lot_number_mix" class="form-label">{{ __('Lot Number Mix') }}</label>
-                        <select id="lot_number_mix" name="lot_number_mix" class="form-select">
-                            <option value="">-- Pilih Lot Number --</option>
-                            @foreach($stocks as $item)
-                                <option value="{{ $item->lot_number }}">{{ $item->lot_number }}</option>
-                            @endforeach
-                        </select>
-                    </div>
+                    <label for="lot_number_mix" class="form-label">{{ __('Lot Number Mix') }}</label>
+                    <input list="lot_numbers" id="lot_number_mix" name="lot_number_mix" class="form-control" placeholder="-- Pilih Lot Number --" />
+                </div>
                     <div class="col-md-6">
                         <label for="qty_awal_mix" class="form-label">{{ __('QTY Awal Mix') }}</label>
                         <input type="text" inputmode="decimal" id="qty_awal_mix" name="qty_awal_mix" class="form-control" />
@@ -142,9 +137,9 @@
             return parseFloat(val) || 0;
         }
 
-        document.getElementById('lot_number').addEventListener('change', function () {
-            const option = this.options[this.selectedIndex];
-            document.getElementById('nama_barang').value = option.dataset.namaBarang || '';
+        document.getElementById('lot_number').addEventListener('input', function () {
+            const option = document.querySelector(`#lot_numbers option[value="${this.value}"]`);
+            document.getElementById('nama_barang').value = option ? option.dataset.namaBarang || '' : '';
         });
 
         function updateLoss() {
@@ -188,8 +183,8 @@
         document.getElementById('qty_aktual').addEventListener('input', updateLoss);
         document.getElementById('ke').addEventListener('change', toggleMixOption);
         document.getElementById('di_mix').addEventListener('change', toggleMixDetails);
-        document.getElementById('lot_number').addEventListener('change', updateMixName);
-        document.getElementById('lot_number_mix').addEventListener('change', updateMixName);
+        document.getElementById('lot_number').addEventListener('input', updateMixName);
+        document.getElementById('lot_number_mix').addEventListener('input', updateMixName);
         toggleMixOption();
         toggleMixDetails();
     </script>

--- a/resources/views/ttpb/create.blade.php
+++ b/resources/views/ttpb/create.blade.php
@@ -8,6 +8,11 @@
     <div class="card-body">
         <form method="POST" action="{{ route($role.'.ttpb.store') }}">
             @csrf
+            <datalist id="lot_numbers">
+                @foreach($stocks as $item)
+                    <option value="{{ $item->lot_number }}" data-nama-barang="{{ $item->nama_barang }}"></option>
+                @endforeach
+            </datalist>
             <div id="current-item"></div>
             <div id="items-container" class="d-none"></div>
             <button type="button" class="btn btn-secondary mt-3" id="add-row">{{ __('Tambah Baris') }}</button>
@@ -58,12 +63,7 @@
                     </div>
                     <div class="col-md-6">
                         <label class="form-label">{{ __('Lot Number') }}</label>
-                        <select class="form-select lot-number" data-name="lot_number">
-                            <option value="">-- Pilih Lot Number --</option>
-                            @foreach($stocks as $item)
-                                <option value="{{ $item->lot_number }}" data-nama-barang="{{ $item->nama_barang }}">{{ $item->lot_number }}</option>
-                            @endforeach
-                        </select>
+                        <input list="lot_numbers" class="form-control lot-number" data-name="lot_number" placeholder="-- Pilih Lot Number --" />
                     </div>
                     <div class="col-md-6">
                         <label class="form-label">{{ __('Nama Barang') }}</label>
@@ -194,9 +194,9 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     function attachEvents(row) {
-        row.querySelector('.lot-number').addEventListener('change', function () {
-            const option = this.options[this.selectedIndex];
-            row.querySelector('.nama-barang').value = option.dataset.namaBarang || '';
+        row.querySelector('.lot-number').addEventListener('input', function () {
+            const option = document.querySelector(`#lot_numbers option[value="${this.value}"]`);
+            row.querySelector('.nama-barang').value = option ? option.dataset.namaBarang || '' : '';
             refreshPreview();
         });
         row.querySelectorAll('.qty-awal, .qty-aktual').forEach(el => {


### PR DESCRIPTION
## Summary
- allow typing and searching Lot Number values using datalist across TTPB forms
- update scripts to map lot numbers to item names on input

## Testing
- `./vendor/bin/pest`


------
https://chatgpt.com/codex/tasks/task_b_6893731be00c8325a8a634c553b1c468