### PR TITLE
Add searchable Lot Number datalists

### DIFF
--- a/app/Http/Controllers/BpgController.php
+++ b/app/Http/Controllers/BpgController.php
@@ -9,7 +9,8 @@ class BpgController extends Controller
 {
     public function edit(Bpg $bpg)
     {
-        return view('bpg.edit', ['record' => $bpg]);
+        $lotNumbers = Bpg::pluck('lot_number');
+        return view('bpg.edit', ['record' => $bpg, 'lotNumbers' => $lotNumbers]);
     }
 
     public function update(Request $request, Bpg $bpg)

--- a/app/Http/Controllers/TtpbController.php
+++ b/app/Http/Controllers/TtpbController.php
@@ -12,7 +12,8 @@ class TtpbController extends Controller
 {
     public function edit(Ttpb $ttpb)
     {
-        return view('ttpb.edit', ['record' => $ttpb]);
+        $lotNumbers = Bpg::pluck('lot_number')->merge(Ttpb::pluck('lot_number'))->unique();
+        return view('ttpb.edit', ['record' => $ttpb, 'lotNumbers' => $lotNumbers]);
     }
 
     public function update(Request $request, Ttpb $ttpb)

--- a/resources/views/blower/stock-create.blade.php
+++ b/resources/views/blower/stock-create.blade.php
@@ -18,7 +18,12 @@
                 </div>
                 <div class="col-md-6">
                     <label for="lot_number" class="form-label">{{ __('Lot Number') }}</label>
-                    <input type="text" id="lot_number" class="form-control" />
+                    <input list="lot_numbers" id="lot_number" name="lot_number" class="form-control" placeholder="-- Pilih Lot Number --" />
+                    <datalist id="lot_numbers">
+                        @foreach($lotNumbers as $lot)
+                            <option value="{{ $lot }}"></option>
+                        @endforeach
+                    </datalist>
                 </div>
                 <div class="col-md-6">
                     <label for="supplier" class="form-label">{{ __('Supplier') }}</label>

--- a/resources/views/bpg/edit.blade.php
+++ b/resources/views/bpg/edit.blade.php
@@ -19,7 +19,12 @@
                     </div>
                     <div class="col-md-6">
                         <label for="lot_number" class="form-label">{{ __('Lot Number') }}</label>
-                        <input type="text" id="lot_number" name="lot_number" class="form-control" value="{{ old('lot_number', $record->lot_number) }}" />
+                        <input list="lot_numbers" id="lot_number" name="lot_number" class="form-control" value="{{ old('lot_number', $record->lot_number) }}" placeholder="-- Pilih Lot Number --" />
+                        <datalist id="lot_numbers">
+                            @foreach($lotNumbers as $lot)
+                                <option value="{{ $lot }}"></option>
+                            @endforeach
+                        </datalist>
                     </div>
                     <div class="col-md-6">
                         <label for="supplier" class="form-label">{{ __('Supplier') }}</label>

--- a/resources/views/finish_good/stock-create.blade.php
+++ b/resources/views/finish_good/stock-create.blade.php
@@ -18,7 +18,12 @@
                 </div>
                 <div class="col-md-6">
                     <label for="lot_number" class="form-label">{{ __('Lot Number') }}</label>
-                    <input type="text" id="lot_number" class="form-control" />
+                    <input list="lot_numbers" id="lot_number" name="lot_number" class="form-control" placeholder="-- Pilih Lot Number --" />
+                    <datalist id="lot_numbers">
+                        @foreach($lotNumbers as $lot)
+                            <option value="{{ $lot }}"></option>
+                        @endforeach
+                    </datalist>
                 </div>
                 <div class="col-md-6">
                     <label for="supplier" class="form-label">{{ __('Supplier') }}</label>

--- a/resources/views/grinding/stock-create.blade.php
+++ b/resources/views/grinding/stock-create.blade.php
@@ -18,7 +18,12 @@
                 </div>
                 <div class="col-md-6">
                     <label for="lot_number" class="form-label">{{ __('Lot Number') }}</label>
-                    <input type="text" id="lot_number" class="form-control" />
+                    <input list="lot_numbers" id="lot_number" name="lot_number" class="form-control" placeholder="-- Pilih Lot Number --" />
+                    <datalist id="lot_numbers">
+                        @foreach($lotNumbers as $lot)
+                            <option value="{{ $lot }}"></option>
+                        @endforeach
+                    </datalist>
                 </div>
                 <div class="col-md-6">
                     <label for="supplier" class="form-label">{{ __('Supplier') }}</label>

--- a/resources/views/gudang/partials/stock-form.blade.php
+++ b/resources/views/gudang/partials/stock-form.blade.php
@@ -16,7 +16,12 @@
                 </div>
                 <div class="col-md-6">
                     <label for="lot_number" class="form-label">{{ __('Lot Number') }}</label>
-                    <input type="text" id="lot_number" name="lot_number" class="form-control" />
+                    <input list="lot_numbers" id="lot_number" name="lot_number" class="form-control" placeholder="-- Pilih Lot Number --" />
+                    <datalist id="lot_numbers">
+                        @foreach($lotNumbers as $lot)
+                            <option value="{{ $lot }}"></option>
+                        @endforeach
+                    </datalist>
                 </div>
                 <div class="col-md-6">
                     <label for="supplier" class="form-label">{{ __('Supplier') }}</label>

--- a/resources/views/gudang/stock-create.blade.php
+++ b/resources/views/gudang/stock-create.blade.php
@@ -1,5 +1,5 @@
 @section('title', __('Input BPG'))
 <x-layouts.app :title="__('Input BPG')">
 
-@include('gudang.partials.stock-form')
+@include('gudang.partials.stock-form', ['lotNumbers' => $lotNumbers])
 </x-layouts.app>

--- a/resources/views/mixing/stock-create.blade.php
+++ b/resources/views/mixing/stock-create.blade.php
@@ -18,7 +18,12 @@
                 </div>
                 <div class="col-md-6">
                     <label for="lot_number" class="form-label">{{ __('Lot Number') }}</label>
-                    <input type="text" id="lot_number" class="form-control" />
+                    <input list="lot_numbers" id="lot_number" name="lot_number" class="form-control" placeholder="-- Pilih Lot Number --" />
+                    <datalist id="lot_numbers">
+                        @foreach($lotNumbers as $lot)
+                            <option value="{{ $lot }}"></option>
+                        @endforeach
+                    </datalist>
                 </div>
                 <div class="col-md-6">
                     <label for="supplier" class="form-label">{{ __('Supplier') }}</label>

--- a/resources/views/packaging/stock-create.blade.php
+++ b/resources/views/packaging/stock-create.blade.php
@@ -18,7 +18,12 @@
                 </div>
                 <div class="col-md-6">
                     <label for="lot_number" class="form-label">{{ __('Lot Number') }}</label>
-                    <input type="text" id="lot_number" class="form-control" />
+                    <input list="lot_numbers" id="lot_number" name="lot_number" class="form-control" placeholder="-- Pilih Lot Number --" />
+                    <datalist id="lot_numbers">
+                        @foreach($lotNumbers as $lot)
+                            <option value="{{ $lot }}"></option>
+                        @endforeach
+                    </datalist>
                 </div>
                 <div class="col-md-6">
                     <label for="supplier" class="form-label">{{ __('Supplier') }}</label>

--- a/resources/views/pencucian/stock-create.blade.php
+++ b/resources/views/pencucian/stock-create.blade.php
@@ -18,7 +18,12 @@
                 </div>
                 <div class="col-md-6">
                     <label for="lot_number" class="form-label">{{ __('Lot Number') }}</label>
-                    <input type="text" id="lot_number" class="form-control" />
+                    <input list="lot_numbers" id="lot_number" name="lot_number" class="form-control" placeholder="-- Pilih Lot Number --" />
+                    <datalist id="lot_numbers">
+                        @foreach($lotNumbers as $lot)
+                            <option value="{{ $lot }}"></option>
+                        @endforeach
+                    </datalist>
                 </div>
                 <div class="col-md-6">
                     <label for="supplier" class="form-label">{{ __('Supplier') }}</label>

--- a/resources/views/pengeringan/stock-create.blade.php
+++ b/resources/views/pengeringan/stock-create.blade.php
@@ -18,7 +18,12 @@
                 </div>
                 <div class="col-md-6">
                     <label for="lot_number" class="form-label">{{ __('Lot Number') }}</label>
-                    <input type="text" id="lot_number" class="form-control" />
+                    <input list="lot_numbers" id="lot_number" name="lot_number" class="form-control" placeholder="-- Pilih Lot Number --" />
+                    <datalist id="lot_numbers">
+                        @foreach($lotNumbers as $lot)
+                            <option value="{{ $lot }}"></option>
+                        @endforeach
+                    </datalist>
                 </div>
                 <div class="col-md-6">
                     <label for="supplier" class="form-label">{{ __('Supplier') }}</label>

--- a/resources/views/ttpb/edit.blade.php
+++ b/resources/views/ttpb/edit.blade.php
@@ -19,7 +19,12 @@
                     </div>
                     <div class="col-md-6">
                         <label for="lot_number" class="form-label">{{ __('Lot Number') }}</label>
-                        <input type="text" id="lot_number" name="lot_number" class="form-control" value="{{ old('lot_number', $record->lot_number) }}" />
+                        <input list="lot_numbers" id="lot_number" name="lot_number" class="form-control" value="{{ old('lot_number', $record->lot_number) }}" placeholder="-- Pilih Lot Number --" />
+                        <datalist id="lot_numbers">
+                            @foreach($lotNumbers as $lot)
+                                <option value="{{ $lot }}"></option>
+                            @endforeach
+                        </datalist>
                     </div>
                     <div class="col-md-6">
                         <label for="nama_barang" class="form-label">{{ __('Nama Barang') }}</label>

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\Route;
 use Livewire\Volt\Volt;
 use App\Http\Controllers\TtpbController;
 use App\Http\Controllers\BpgController;
+use App\Models\Bpg;
 use Carbon\Carbon;
 
 Route::get('/', function () {
@@ -51,7 +52,10 @@ Route::middleware(['auth'])->group(function () {
 
       return view("{$role}.stock", ['role' => $role, 'records' => $records]);
     })->name("{$role}.stock");
-    Route::get("{$role}/stock/create", fn () => view("{$role}.stock-create"))->name("{$role}.stock.create");
+    Route::get("{$role}/stock/create", function () use ($role) {
+      $lotNumbers = Bpg::pluck('lot_number');
+      return view("{$role}.stock-create", ['lotNumbers' => $lotNumbers]);
+    })->name("{$role}.stock.create");
     if ($role === 'gudang') {
       Route::post("{$role}/stock", [BpgController::class, 'store'])->name("{$role}.stock.store");
     }


### PR DESCRIPTION
## Summary
- make stock creation routes supply existing Lot Numbers
- allow typing or choosing Lot Numbers via datalist in stock and edit forms

## Testing
- `./vendor/bin/pest`

------
https://chatgpt.com/codex/tasks/task_b_6893835e022c8325a4a656197cacfc89