### PR TITLE
feat: add basic API endpoints for inventory

### DIFF
--- a/app/Http/Controllers/Api/BpgController.php
+++ b/app/Http/Controllers/Api/BpgController.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Bpg;
+use Illuminate\Http\Request;
+
+class BpgController extends Controller
+{
+    public function index()
+    {
+        return Bpg::all();
+    }
+
+    public function show(Bpg $bpg)
+    {
+        return $bpg;
+    }
+
+    public function store(Request $request)
+    {
+        $request->merge([
+            'qty' => $this->normalizeNumber($request->input('qty')),
+            'qty_aktual' => $this->normalizeNumber($request->input('qty_aktual')),
+            'qty_loss' => $this->normalizeNumber($request->input('qty_loss')),
+        ]);
+
+        $validated = $request->validate([
+            'tanggal' => 'required|date',
+            'no_bpg' => 'required|string',
+            'lot_number' => 'required|string',
+            'supplier' => 'required|string',
+            'nomor_mobil' => 'required|string',
+            'nama_barang' => 'required|string',
+            'qty' => 'required|numeric',
+            'qty_aktual' => 'required|numeric',
+            'qty_loss' => 'nullable|numeric',
+            'coly' => 'nullable|string',
+            'diterima' => 'required|string',
+            'ttpb' => 'required|string',
+        ]);
+
+        $validated['qty_loss'] = $validated['qty'] - $validated['qty_aktual'];
+
+        $bpg = Bpg::create($validated);
+
+        return response()->json($bpg, 201);
+    }
+
+    public function destroy(Bpg $bpg)
+    {
+        $bpg->delete();
+
+        return response()->noContent();
+    }
+
+    private function normalizeNumber($value)
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $value = trim($value);
+
+        if (strpos($value, ',') !== false && strpos($value, '.') !== false) {
+            $value = str_replace('.', '', $value);
+            $value = str_replace(',', '.', $value);
+        } else {
+            $value = str_replace(',', '.', $value);
+        }
+
+        return (float) $value;
+    }
+}

--- a/app/Http/Controllers/Api/TtpbController.php
+++ b/app/Http/Controllers/Api/TtpbController.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Ttpb;
+use App\Models\Bpg;
+use Illuminate\Http\Request;
+
+class TtpbController extends Controller
+{
+    public function index()
+    {
+        return Ttpb::all();
+    }
+
+    public function show(Ttpb $ttpb)
+    {
+        return $ttpb;
+    }
+
+    public function store(Request $request)
+    {
+        $request->merge([
+            'qty_awal' => $this->normalizeNumber($request->input('qty_awal')),
+            'qty_aktual' => $this->normalizeNumber($request->input('qty_aktual')),
+            'qty_loss' => $this->normalizeNumber($request->input('qty_loss')),
+        ]);
+
+        $validated = $request->validate([
+            'tanggal' => 'required|date',
+            'no_ttpb' => 'required|string',
+            'lot_number' => 'required|string',
+            'nama_barang' => 'required|string',
+            'qty_awal' => 'required|numeric',
+            'qty_aktual' => 'required|numeric',
+            'qty_loss' => 'nullable|numeric',
+            'persen_loss' => 'nullable|numeric',
+            'kadar_air' => 'nullable|numeric|prohibited_unless:dari,pencucian',
+            'deviasi' => 'nullable|numeric|prohibited_unless:dari,pencucian',
+            'coly' => 'nullable|string',
+            'spec' => 'nullable|string',
+            'keterangan' => 'nullable|string',
+            'ke' => 'required|string',
+            'dari' => 'required|string',
+        ]);
+
+        $saldo = $this->calculateSaldo($validated['lot_number'], $validated['dari']);
+        if ($validated['qty_awal'] > $saldo) {
+            return response()->json(['message' => 'QTY tidak mencukupi'], 422);
+        }
+
+        $ttpb = Ttpb::create($validated);
+
+        return response()->json($ttpb, 201);
+    }
+
+    public function destroy(Ttpb $ttpb)
+    {
+        $ttpb->delete();
+
+        return response()->noContent();
+    }
+
+    private function calculateSaldo(string $lot, string $role): float
+    {
+        if ($role === 'gudang') {
+            $incoming = Bpg::where('lot_number', $lot)->sum('qty')
+                + Ttpb::where('ke', 'gudang')->where('lot_number', $lot)->sum('qty_aktual');
+            $outgoing = Ttpb::where('dari', 'gudang')->where('lot_number', $lot)->sum('qty_awal');
+
+            return $incoming - $outgoing;
+        }
+
+        $incoming = Ttpb::where('ke', $role)->where('lot_number', $lot)->sum('qty_aktual');
+        $outgoing = Ttpb::where('dari', $role)->where('lot_number', $lot)->sum('qty_awal');
+
+        return $incoming - $outgoing;
+    }
+
+    private function normalizeNumber($value)
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $value = trim($value);
+
+        if (strpos($value, ',') !== false && strpos($value, '.') !== false) {
+            $value = str_replace('.', '', $value);
+            $value = str_replace(',', '.', $value);
+        } else {
+            $value = str_replace(',', '.', $value);
+        }
+
+        return (float) $value;
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Api\BpgController as ApiBpgController;
+use App\Http\Controllers\Api\TtpbController as ApiTtpbController;
+
+Route::get('/bpg', [ApiBpgController::class, 'index']);
+Route::get('/bpg/{bpg}', [ApiBpgController::class, 'show']);
+Route::post('/bpg', [ApiBpgController::class, 'store']);
+Route::delete('/bpg/{bpg}', [ApiBpgController::class, 'destroy']);
+
+Route::get('/ttpb', [ApiTtpbController::class, 'index']);
+Route::get('/ttpb/{ttpb}', [ApiTtpbController::class, 'show']);
+Route::post('/ttpb', [ApiTtpbController::class, 'store']);
+Route::delete('/ttpb/{ttpb}', [ApiTtpbController::class, 'destroy']);


### PR DESCRIPTION
## Summary
- add API routes for BPG and TTPB records
- implement controllers to handle listing, creation, and deletion
- register API route file in application bootstrap

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_b_689459b49a788325bb077de5a992ab80