### PR TITLE
Ensure TTPB storage and preview behavior

### DIFF
--- a/app/Http/Controllers/TtpbController.php
+++ b/app/Http/Controllers/TtpbController.php
@@ -108,9 +108,17 @@ class TtpbController extends Controller
         ]);
 
         $createdIds = [];
+        $role = $validated['items'][0]['dari'];
+
         try {
             DB::beginTransaction();
             foreach ($validated['items'] as $item) {
+                if ($item['dari'] !== $role) {
+                    throw ValidationException::withMessages([
+                        'items.*.dari' => 'Semua baris harus memiliki asal yang sama',
+                    ]);
+                }
+
                 $saldo = $this->calculateSaldo($item['lot_number'], $item['dari']);
 
                 if ($item['qty_awal'] > $saldo) {
@@ -121,7 +129,6 @@ class TtpbController extends Controller
 
                 $record = Ttpb::create($item);
                 $createdIds[] = $record->id;
-                $role = $item['dari'];
             }
             DB::commit();
         } catch (ValidationException $e) {


### PR DESCRIPTION
## Summary
- validate all TTPB rows share the same origin and store created IDs for preview
- add feature test covering preview display and receiving-role stock lookup

## Testing
- `php artisan test --testsuite=Feature --filter=TtpbStoreTest --stop-on-failure`


------
https://chatgpt.com/codex/tasks/task_b_68935b06e49483259b56df2b6f4fddc7