### PR TITLE
Persist TTPB preview across submissions

### DIFF
--- a/app/Http/Controllers/TtpbController.php
+++ b/app/Http/Controllers/TtpbController.php
@@ -132,7 +132,9 @@ class TtpbController extends Controller
                 ->withErrors($e->errors());
         }
 
-        session(["ttpb_preview_ids_{$role}" => $createdIds]);
+        $existingIds = session("ttpb_preview_ids_{$role}", []);
+        $allIds = array_unique(array_merge($existingIds, $createdIds));
+        session(["ttpb_preview_ids_{$role}" => $allIds]);
 
         return redirect()->route("{$role}.ttpb.preview");
     }

--- a/routes/web.php
+++ b/routes/web.php
@@ -96,7 +96,7 @@ Route::middleware(['auth'])->group(function () {
     Route::get("{$role}/ttpb/preview", function () use ($role) {
       $ids = session("ttpb_preview_ids_{$role}", []);
       $records = App\Models\Ttpb::where('dari', $role)
-        ->whereIn('id', $ids)
+        ->whereIn('id', array_unique($ids))
         ->get();
       return view('ttpb.preview', ['role' => $role, 'records' => $records]);
     })->name("{$role}.ttpb.preview");


### PR DESCRIPTION
## Summary
- keep preview IDs from prior TTPB submissions and append newly saved records so multiple cards remain visible
- ensure preview query uses unique IDs to avoid duplicate records

## Testing
- `./vendor/bin/pest`

------
https://chatgpt.com/codex/tasks/task_b_6895cac6b54c83258f5d1621d5177229