### PR TITLE
Ensure TTPB preview session persists

### DIFF
--- a/app/Http/Controllers/TtpbController.php
+++ b/app/Http/Controllers/TtpbController.php
@@ -139,9 +139,9 @@ class TtpbController extends Controller
                 ->withErrors($e->errors());
         }
 
-        $existingIds = session("ttpb_preview_ids_{$role}", []);
-        $allIds = array_unique(array_merge($existingIds, $createdIds));
-        session(["ttpb_preview_ids_{$role}" => $allIds]);
+        $existingIds = session()->get("ttpb_preview_ids_{$role}", []);
+        $allIds = collect($existingIds)->merge($createdIds)->unique()->values()->all();
+        session()->put("ttpb_preview_ids_{$role}", $allIds);
 
         return redirect()->route("{$role}.ttpb.preview");
     }

--- a/routes/web.php
+++ b/routes/web.php
@@ -94,9 +94,9 @@ Route::middleware(['auth'])->group(function () {
     Route::post("{$role}/ttpb", [TtpbController::class, 'store'])->name("{$role}.ttpb.store");
 
     Route::get("{$role}/ttpb/preview", function () use ($role) {
-      $ids = session("ttpb_preview_ids_{$role}", []);
+      $ids = session()->get("ttpb_preview_ids_{$role}", []);
       $records = App\Models\Ttpb::where('dari', $role)
-        ->whereIn('id', array_unique($ids))
+        ->whereIn('id', $ids)
         ->get();
       return view('ttpb.preview', ['role' => $role, 'records' => $records]);
     })->name("{$role}.ttpb.preview");


### PR DESCRIPTION
## Summary
- persist previewed TTPB IDs using explicit session helpers
- load preview records directly from stored session IDs

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_b_6895ce1533548325b01635c6b99c6193