### PR TITLE
Include incoming TTPB items in gudang stock view

### DIFF
--- a/resources/views/gudang/stock.blade.php
+++ b/resources/views/gudang/stock.blade.php
@@ -43,12 +43,21 @@
                             <td>{{ $item->diterima }}</td>
                             <td>{{ $item->ttpb }}</td>
                             <td class="d-flex gap-1">
-                                <a href="{{ route('bpg.edit', $item) }}" class="btn btn-sm btn-warning">Edit</a>
-                                <form method="POST" action="{{ route('bpg.destroy', $item) }}" onsubmit="return confirm('Hapus data?')">
-                                    @csrf
-                                    @method('DELETE')
-                                    <button type="submit" class="btn btn-sm btn-danger">Hapus</button>
-                                </form>
+                                @if ($item instanceof \App\Models\Bpg)
+                                    <a href="{{ route('bpg.edit', $item) }}" class="btn btn-sm btn-warning">Edit</a>
+                                    <form method="POST" action="{{ route('bpg.destroy', $item) }}" onsubmit="return confirm('Hapus data?')">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="submit" class="btn btn-sm btn-danger">Hapus</button>
+                                    </form>
+                                @else
+                                    <a href="{{ route('ttpb.edit', $item) }}" class="btn btn-sm btn-warning">Edit</a>
+                                    <form method="POST" action="{{ route('ttpb.destroy', $item) }}" onsubmit="return confirm('Hapus data?')">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="submit" class="btn btn-sm btn-danger">Hapus</button>
+                                    </form>
+                                @endif
                             </td>
                         </tr>
                     @empty


### PR DESCRIPTION
## Summary
- show TTPB transfers received by gudang in gudang stock page
- update gudang stock view to handle both BPG and TTPB entries
- add regression test ensuring transfers to gudang appear in source and destination lists

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_b_6895d9865e888325921d08669dff219e