### PR TITLE
Allow blank BPG and TTPB submissions

### DIFF
--- a/app/Http/Controllers/Api/BpgController.php
+++ b/app/Http/Controllers/Api/BpgController.php
@@ -27,21 +27,21 @@ class BpgController extends Controller
         ]);
 
         $validated = $request->validate([
-            'tanggal' => 'required|date',
-            'no_bpg' => 'required|string',
-            'lot_number' => 'required|string',
-            'supplier' => 'required|string',
-            'nomor_mobil' => 'required|string',
-            'nama_barang' => 'required|string',
-            'qty' => 'required|numeric',
-            'qty_aktual' => 'required|numeric',
+            'tanggal' => 'nullable|date',
+            'no_bpg' => 'nullable|string',
+            'lot_number' => 'nullable|string',
+            'supplier' => 'nullable|string',
+            'nomor_mobil' => 'nullable|string',
+            'nama_barang' => 'nullable|string',
+            'qty' => 'nullable|numeric',
+            'qty_aktual' => 'nullable|numeric',
             'qty_loss' => 'nullable|numeric',
             'coly' => 'nullable|string',
-            'diterima' => 'required|string',
-            'ttpb' => 'required|string',
+            'diterima' => 'nullable|string',
+            'ttpb' => 'nullable|string',
         ]);
 
-        $validated['qty_loss'] = $validated['qty'] - $validated['qty_aktual'];
+        $validated['qty_loss'] = ($validated['qty'] ?? 0) - ($validated['qty_aktual'] ?? 0);
 
         $bpg = Bpg::create($validated);
 
@@ -57,7 +57,7 @@ class BpgController extends Controller
 
     private function normalizeNumber($value)
     {
-        if ($value === null) {
+        if ($value === null || $value === '') {
             return null;
         }
 

--- a/app/Http/Controllers/Api/TtpbController.php
+++ b/app/Http/Controllers/Api/TtpbController.php
@@ -29,12 +29,12 @@ class TtpbController extends Controller
         ]);
 
         $validated = $request->validate([
-            'tanggal' => 'required|date',
-            'no_ttpb' => 'required|string',
-            'lot_number' => 'required|string',
-            'nama_barang' => 'required|string',
-            'qty_awal' => 'required|numeric',
-            'qty_aktual' => 'required|numeric',
+            'tanggal' => 'nullable|date',
+            'no_ttpb' => 'nullable|string',
+            'lot_number' => 'nullable|string',
+            'nama_barang' => 'nullable|string',
+            'qty_awal' => 'nullable|numeric',
+            'qty_aktual' => 'nullable|numeric',
             'qty_loss' => 'nullable|numeric',
             'persen_loss' => 'nullable|numeric',
             'kadar_air' => 'nullable|numeric|prohibited_unless:dari,pencucian',
@@ -42,12 +42,12 @@ class TtpbController extends Controller
             'coly' => 'nullable|string',
             'spec' => 'nullable|string',
             'keterangan' => 'nullable|string',
-            'ke' => 'required|string',
-            'dari' => 'required|string',
+            'ke' => 'nullable|string',
+            'dari' => 'nullable|string',
         ]);
 
-        $saldo = $this->calculateSaldo($validated['lot_number'], $validated['dari']);
-        if ($validated['qty_awal'] > $saldo) {
+        $saldo = $this->calculateSaldo($validated['lot_number'] ?? '', $validated['dari'] ?? '');
+        if (($validated['qty_awal'] ?? 0) > $saldo) {
             return response()->json(['message' => 'QTY tidak mencukupi'], 422);
         }
 
@@ -67,8 +67,12 @@ class TtpbController extends Controller
 
     private function storeRoleSpecificRecords(array $item): void
     {
-        $this->insertIntoRoleTable($item['dari'] . '_ttpbs', $item);
-        $this->insertIntoRoleTable($item['ke'] . '_ttpbs', $item);
+        if (isset($item['dari'])) {
+            $this->insertIntoRoleTable($item['dari'] . '_ttpbs', $item);
+        }
+        if (isset($item['ke'])) {
+            $this->insertIntoRoleTable($item['ke'] . '_ttpbs', $item);
+        }
     }
 
     private function insertIntoRoleTable(string $table, array $item): void
@@ -127,7 +131,7 @@ class TtpbController extends Controller
 
     private function normalizeNumber($value)
     {
-        if ($value === null) {
+        if ($value === null || $value === '') {
             return null;
         }
 

--- a/app/Http/Controllers/BpgController.php
+++ b/app/Http/Controllers/BpgController.php
@@ -22,21 +22,21 @@ class BpgController extends Controller
         ]);
 
         $validated = $request->validate([
-            'tanggal' => 'required|date',
-            'no_bpg' => 'required|string',
-            'lot_number' => 'required|string',
-            'supplier' => 'required|string',
-            'nomor_mobil' => 'required|string',
-            'nama_barang' => 'required|string',
-            'qty' => 'required|numeric',
-            'qty_aktual' => 'required|numeric',
+            'tanggal' => 'nullable|date',
+            'no_bpg' => 'nullable|string',
+            'lot_number' => 'nullable|string',
+            'supplier' => 'nullable|string',
+            'nomor_mobil' => 'nullable|string',
+            'nama_barang' => 'nullable|string',
+            'qty' => 'nullable|numeric',
+            'qty_aktual' => 'nullable|numeric',
             'qty_loss' => 'nullable|numeric',
             'coly' => 'nullable|string',
-            'diterima' => 'required|string',
-            'ttpb' => 'required|string',
+            'diterima' => 'nullable|string',
+            'ttpb' => 'nullable|string',
         ]);
 
-        $validated['qty_loss'] = $validated['qty'] - $validated['qty_aktual'];
+        $validated['qty_loss'] = ($validated['qty'] ?? 0) - ($validated['qty_aktual'] ?? 0);
 
         $bpg->update($validated);
 
@@ -58,21 +58,21 @@ class BpgController extends Controller
         ]);
 
         $validated = $request->validate([
-            'tanggal' => 'required|date',
-            'no_bpg' => 'required|string',
-            'lot_number' => 'required|string',
-            'supplier' => 'required|string',
-            'nomor_mobil' => 'required|string',
-            'nama_barang' => 'required|string',
-            'qty' => 'required|numeric',
-            'qty_aktual' => 'required|numeric',
+            'tanggal' => 'nullable|date',
+            'no_bpg' => 'nullable|string',
+            'lot_number' => 'nullable|string',
+            'supplier' => 'nullable|string',
+            'nomor_mobil' => 'nullable|string',
+            'nama_barang' => 'nullable|string',
+            'qty' => 'nullable|numeric',
+            'qty_aktual' => 'nullable|numeric',
             'qty_loss' => 'nullable|numeric',
             'coly' => 'nullable|string',
-            'diterima' => 'required|string',
-            'ttpb' => 'required|string',
+            'diterima' => 'nullable|string',
+            'ttpb' => 'nullable|string',
         ]);
 
-        $validated['qty_loss'] = $validated['qty'] - $validated['qty_aktual'];
+        $validated['qty_loss'] = ($validated['qty'] ?? 0) - ($validated['qty_aktual'] ?? 0);
 
         Bpg::create($validated);
 
@@ -81,7 +81,7 @@ class BpgController extends Controller
 
     private function normalizeNumber($value)
     {
-        if ($value === null) {
+        if ($value === null || $value === '') {
             return null;
         }
 


### PR DESCRIPTION
## Summary
- allow BPG submissions even when form fields are empty
- permit empty TTPB form values and safely handle missing role data
- mirror optional-field behavior in BPG and TTPB API endpoints

## Testing
- `./vendor/bin/pest`


------
https://chatgpt.com/codex/tasks/task_b_6897238dc2a08325a71a05f230a219bc