### PR TITLE
Require quantity fields for TTPB entries

### DIFF
--- a/app/Http/Controllers/Api/TtpbController.php
+++ b/app/Http/Controllers/Api/TtpbController.php
@@ -33,8 +33,8 @@ class TtpbController extends Controller
             'no_ttpb' => 'nullable|string',
             'lot_number' => 'nullable|string',
             'nama_barang' => 'nullable|string',
-            'qty_awal' => 'nullable|numeric',
-            'qty_aktual' => 'nullable|numeric',
+            'qty_awal' => 'required|numeric',
+            'qty_aktual' => 'required|numeric',
             'qty_loss' => 'nullable|numeric',
             'persen_loss' => 'nullable|numeric',
             'kadar_air' => 'nullable|numeric|prohibited_unless:dari,pencucian',
@@ -47,7 +47,7 @@ class TtpbController extends Controller
         ]);
 
         $saldo = $this->calculateSaldo($validated['lot_number'] ?? '', $validated['dari'] ?? '');
-        if (($validated['qty_awal'] ?? 0) > $saldo) {
+        if ($validated['qty_awal'] > $saldo) {
             return response()->json(['message' => 'QTY tidak mencukupi'], 422);
         }
 

--- a/app/Http/Controllers/TtpbController.php
+++ b/app/Http/Controllers/TtpbController.php
@@ -47,8 +47,8 @@ class TtpbController extends Controller
             'no_ttpb' => 'nullable|string',
             'lot_number' => 'nullable|string',
             'nama_barang' => 'nullable|string',
-            'qty_awal' => 'nullable|numeric',
-            'qty_aktual' => 'nullable|numeric',
+            'qty_awal' => 'required|numeric',
+            'qty_aktual' => 'required|numeric',
             'qty_loss' => 'nullable|numeric',
             'persen_loss' => 'nullable|numeric',
             'kadar_air' => 'nullable|numeric|prohibited_unless:dari,pencucian',
@@ -131,8 +131,8 @@ class TtpbController extends Controller
             'items.*.no_ttpb' => 'nullable|string',
             'items.*.lot_number' => 'nullable|string',
             'items.*.nama_barang' => 'nullable|string',
-            'items.*.qty_awal' => 'nullable|numeric',
-            'items.*.qty_aktual' => 'nullable|numeric',
+            'items.*.qty_awal' => 'required|numeric',
+            'items.*.qty_aktual' => 'required|numeric',
             'items.*.qty_loss' => 'nullable|numeric',
             'items.*.persen_loss' => 'nullable|numeric',
             'items.*.kadar_air' => 'nullable|numeric|prohibited_unless:items.*.dari,pencucian',
@@ -160,7 +160,7 @@ class TtpbController extends Controller
 
                 // Check if the quantity is sufficient
                 $saldo = $this->calculateSaldo($item['lot_number'] ?? '', $item['dari'] ?? '');
-                if (($item['qty_awal'] ?? 0) > $saldo) {
+                if ($item['qty_awal'] > $saldo) {
                     throw ValidationException::withMessages([
                         'qty_awal' => 'QTY tidak mencukupi',
                     ]);


### PR DESCRIPTION
## Summary
- mark qty_awal and qty_aktual as required when storing or updating TTPB records
- enforce quantity requirements in API controller and saldo checks

## Testing
- `./vendor/bin/pest`


------
https://chatgpt.com/codex/tasks/task_b_68972b5323b48325a82dee8d76fe95d4