### PR TITLE
Validate origin and destination for TTPB records

### DIFF
--- a/app/Http/Controllers/Api/TtpbController.php
+++ b/app/Http/Controllers/Api/TtpbController.php
@@ -42,11 +42,11 @@ class TtpbController extends Controller
             'coly' => 'nullable|string',
             'spec' => 'nullable|string',
             'keterangan' => 'nullable|string',
-            'ke' => 'nullable|string',
-            'dari' => 'nullable|string',
+            'ke' => 'required|string',
+            'dari' => 'required|string',
         ]);
 
-        $saldo = $this->calculateSaldo($validated['lot_number'] ?? '', $validated['dari'] ?? '');
+        $saldo = $this->calculateSaldo($validated['lot_number'], $validated['dari']);
         if ($validated['qty_awal'] > $saldo) {
             return response()->json(['message' => 'QTY tidak mencukupi'], 422);
         }

--- a/app/Http/Controllers/TtpbController.php
+++ b/app/Http/Controllers/TtpbController.php
@@ -56,12 +56,12 @@ class TtpbController extends Controller
             'coly' => 'nullable|string',
             'spec' => 'nullable|string',
             'keterangan' => 'nullable|string',
-            'ke' => 'nullable|string',
-            'dari' => 'nullable|string',
+            'ke' => 'required|string',
+            'dari' => 'required|string',
         ]);
 
-        // Determine the role from validated data or default to 'gudang'
-        $role = $validated['dari'] ?? 'gudang';
+        // Determine the role from validated data
+        $role = $validated['dari'];
 
         // Update the TTPB record
         $ttpb->update($validated);
@@ -140,19 +140,19 @@ class TtpbController extends Controller
             'items.*.coly' => 'nullable|string',
             'items.*.spec' => 'nullable|string',
             'items.*.keterangan' => 'nullable|string',
-            'items.*.ke' => 'nullable|string',
-            'items.*.dari' => 'nullable|string',
+            'items.*.ke' => 'required|string',
+            'items.*.dari' => 'required|string',
         ]);
 
         $createdIds = [];
-        $role = $validated['items'][0]['dari'] ?? 'gudang';
+        $role = $validated['items'][0]['dari'];
 
         try {
             DB::beginTransaction();
 
             // Process each item and store it
             foreach ($validated['items'] as $item) {
-                if (($item['dari'] ?? $role) !== $role) {
+                if ($item['dari'] !== $role) {
                     throw ValidationException::withMessages([
                         'items.*.dari' => 'Semua baris harus memiliki asal yang sama',
                     ]);

--- a/tests/Feature/TtpbStoreTest.php
+++ b/tests/Feature/TtpbStoreTest.php
@@ -40,6 +40,35 @@ test('store ttpb redirects to ttpb index', function () {
     $this->assertDatabaseHas('ttpbs', ['no_ttpb' => 'TTPB-001']);
 });
 
+test('store ttpb requires origin and destination roles', function () {
+    $user = User::factory()->create(['role' => 'gudang']);
+    $this->actingAs($user);
+
+    \App\Models\Bpg::factory()->create([
+        'lot_number' => 'LOT-X',
+        'qty' => 10,
+        'nama_barang' => 'Barang',
+        'supplier' => 'Supp',
+    ]);
+
+    $payload = [
+        'tanggal' => '2024-01-01',
+        'no_ttpb' => 'TTPB-404',
+        'lot_number' => 'LOT-X',
+        'nama_barang' => 'Barang',
+        'qty_awal' => 5,
+        'qty_aktual' => 5,
+        'qty_loss' => 0,
+        'persen_loss' => 0,
+        // intentionally omit dari and ke
+    ];
+
+    $this->post('/gudang/ttpb', $payload)
+        ->assertSessionHasErrors(['items.0.dari', 'items.0.ke']);
+
+    $this->assertDatabaseCount('ttpbs', 0);
+});
+
 test('store ttpb accepts qty values with comma', function () {
     $user = User::factory()->create(['role' => 'gudang']);
     $this->actingAs($user);


### PR DESCRIPTION
## Summary
- enforce required `dari` and `ke` fields when storing or updating TTPB entries
- require `dari` and `ke` via API and web controllers
- add regression test ensuring missing origin/destination fails validation

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_b_689737ebe6848325bd77af88c225dfe2