### PR TITLE
Enforce unique lot numbers for BPG and TTPB

### DIFF
--- a/app/Http/Controllers/Api/BpgController.php
+++ b/app/Http/Controllers/Api/BpgController.php
@@ -29,7 +29,7 @@ class BpgController extends Controller
         $validated = $request->validate([
             'tanggal' => 'nullable|date',
             'no_bpg' => 'nullable|string',
-            'lot_number' => 'nullable|string',
+            'lot_number' => 'nullable|string|unique:bpgs,lot_number',
             'supplier' => 'nullable|string',
             'nomor_mobil' => 'nullable|string',
             'nama_barang' => 'nullable|string',

--- a/app/Http/Controllers/Api/TtpbController.php
+++ b/app/Http/Controllers/Api/TtpbController.php
@@ -31,7 +31,7 @@ class TtpbController extends Controller
         $validated = $request->validate([
             'tanggal' => 'nullable|date',
             'no_ttpb' => 'nullable|string',
-            'lot_number' => 'nullable|string',
+            'lot_number' => 'nullable|string|unique:ttpbs,lot_number',
             'nama_barang' => 'nullable|string',
             'qty_awal' => 'required|numeric',
             'qty_aktual' => 'required|numeric',

--- a/app/Http/Controllers/BpgController.php
+++ b/app/Http/Controllers/BpgController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Bpg;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 
 class BpgController extends Controller
 {
@@ -24,7 +25,7 @@ class BpgController extends Controller
         $validated = $request->validate([
             'tanggal' => 'nullable|date',
             'no_bpg' => 'nullable|string',
-            'lot_number' => 'nullable|string',
+            'lot_number' => ['nullable', 'string', Rule::unique('bpgs', 'lot_number')->ignore($bpg->id)],
             'supplier' => 'nullable|string',
             'nomor_mobil' => 'nullable|string',
             'nama_barang' => 'nullable|string',
@@ -60,7 +61,7 @@ class BpgController extends Controller
         $validated = $request->validate([
             'tanggal' => 'nullable|date',
             'no_bpg' => 'nullable|string',
-            'lot_number' => 'nullable|string',
+            'lot_number' => 'nullable|string|unique:bpgs,lot_number',
             'supplier' => 'nullable|string',
             'nomor_mobil' => 'nullable|string',
             'nama_barang' => 'nullable|string',

--- a/app/Http/Controllers/TtpbController.php
+++ b/app/Http/Controllers/TtpbController.php
@@ -7,6 +7,7 @@ use App\Models\Bpg;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
+use Illuminate\Validation\Rule;
 
 class TtpbController extends Controller
 {
@@ -45,7 +46,7 @@ class TtpbController extends Controller
         $validated = $request->validate([
             'tanggal' => 'nullable|date',
             'no_ttpb' => 'nullable|string',
-            'lot_number' => 'nullable|string',
+            'lot_number' => ['nullable', 'string', Rule::unique('ttpbs', 'lot_number')->ignore($ttpb->id)],
             'nama_barang' => 'nullable|string',
             'qty_awal' => 'required|numeric',
             'qty_aktual' => 'required|numeric',
@@ -129,7 +130,7 @@ class TtpbController extends Controller
             'items' => 'required|array|min:1',
             'items.*.tanggal' => 'nullable|date',
             'items.*.no_ttpb' => 'nullable|string',
-            'items.*.lot_number' => 'nullable|string',
+            'items.*.lot_number' => 'nullable|string|unique:ttpbs,lot_number',
             'items.*.nama_barang' => 'nullable|string',
             'items.*.qty_awal' => 'required|numeric',
             'items.*.qty_aktual' => 'required|numeric',

--- a/database/migrations/2025_08_09_000000_add_unique_lot_number_to_bpgs_and_ttpbs_tables.php
+++ b/database/migrations/2025_08_09_000000_add_unique_lot_number_to_bpgs_and_ttpbs_tables.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('bpgs', function (Blueprint $table) {
+            $table->unique('lot_number');
+        });
+
+        Schema::table('ttpbs', function (Blueprint $table) {
+            $table->unique('lot_number');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('bpgs', function (Blueprint $table) {
+            $table->dropUnique('bpgs_lot_number_unique');
+        });
+
+        Schema::table('ttpbs', function (Blueprint $table) {
+            $table->dropUnique('ttpbs_lot_number_unique');
+        });
+    }
+};

--- a/tests/Feature/BpgStoreTest.php
+++ b/tests/Feature/BpgStoreTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('duplicate lot number in bpg is rejected', function () {
+    $user = User::factory()->create(['role' => 'gudang']);
+    $this->actingAs($user);
+
+    $payload = [
+        'tanggal' => '2024-01-01',
+        'no_bpg' => 'BPG-001',
+        'lot_number' => 'LOT-1',
+        'supplier' => 'Supp',
+        'nomor_mobil' => 'AB-123',
+        'nama_barang' => 'Barang',
+        'qty' => 5,
+        'qty_aktual' => 5,
+        'qty_loss' => 0,
+        'diterima' => 'A',
+        'ttpb' => 'TTPB-1',
+    ];
+
+    $this->post('/gudang/stock', $payload)->assertRedirect('/gudang/stock');
+
+    $this->post('/gudang/stock', $payload)
+        ->assertSessionHasErrors(['lot_number']);
+
+    $this->assertDatabaseCount('bpgs', 1);
+});

--- a/tests/Feature/MonitoringTest.php
+++ b/tests/Feature/MonitoringTest.php
@@ -40,15 +40,6 @@ test('gudang monitoring shows sequential entries with running saldo', function (
     Ttpb::factory()->create([
         'lot_number' => 'LOT-2',
         'nama_barang' => 'Barang',
-        'qty_awal' => 5,
-        'qty_aktual' => 5,
-        'dari' => 'mixing',
-        'ke' => 'gudang',
-    ]);
-
-    Ttpb::factory()->create([
-        'lot_number' => 'LOT-2',
-        'nama_barang' => 'Barang',
         'qty_awal' => 3,
         'qty_aktual' => 3,
         'dari' => 'gudang',
@@ -58,12 +49,10 @@ test('gudang monitoring shows sequential entries with running saldo', function (
     $this->get('/gudang/monitoring?lot=LOT-2')
         ->assertOk()
         ->assertViewHas('records', function ($records) {
-            return $records->count() === 3
+            return $records->count() === 2
                 && $records[0]['qty_in_bpg'] == 10
                 && $records[0]['saldo'] == 10
-                && $records[1]['qty_in_ttpb'] == 5
-                && $records[1]['saldo'] == 15
-                && $records[2]['qty_out_ttpb'] == 3
-                && $records[2]['saldo'] == 12;
+                && $records[1]['qty_out_ttpb'] == 3
+                && $records[1]['saldo'] == 7;
         });
 });


### PR DESCRIPTION
## Summary
- enforce unique lot number columns for `bpgs` and `ttpbs`
- validate lot numbers are unique in HTTP and API controllers
- add regression tests covering duplicate lot number rejection

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_689d8845d1308330ad590db52f1eeb3d