### PR TITLE
feat: prefill TTPB form from previous data

### DIFF
--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -240,7 +240,9 @@ class RoleController extends Controller
     public function gudangBpg(string $lotNumber)
     {
         return Bpg::where('lot_number', $lotNumber)
-            ->first(['nama_barang', 'qty']);
+            ->orderByDesc('tanggal')
+            ->orderByDesc('id')
+            ->first(['nama_barang', 'qty', 'qty_aktual', 'coly']);
     }
 
     public function roleTtpbShow(string $role, string $lotNumber)
@@ -249,7 +251,19 @@ class RoleController extends Controller
 
         return Ttpb::where('ke', $role)
             ->where('lot_number', $lotNumber)
-            ->first(['nama_barang', 'qty_aktual']);
+            ->orderByDesc('tanggal')
+            ->orderByDesc('id')
+            ->first(['nama_barang', 'qty_aktual', 'qty_loss', 'persen_loss', 'coly', 'spec', 'keterangan']);
+    }
+
+    public function roleTtpbLast(string $role)
+    {
+        abort_unless(in_array($role, $this->roles), 404);
+
+        return Ttpb::where('dari', $role)
+            ->orderByDesc('tanggal')
+            ->orderByDesc('id')
+            ->first();
     }
 }
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -54,6 +54,9 @@ Route::middleware(['auth'])->group(function () {
     Route::get('{role}/api/ttpb/{lotNumber}', [RoleController::class, 'roleTtpbShow'])
         ->whereIn('role', $roles)
         ->name('role.ttpb.show');
+    Route::get('{role}/api/ttpb-last', [RoleController::class, 'roleTtpbLast'])
+        ->whereIn('role', $roles)
+        ->name('role.ttpb.last');
 });
 
 require __DIR__ . '/auth.php';


### PR DESCRIPTION
## Summary
- auto-populate TTPB form fields from latest record or BPG
- add endpoint to fetch last TTPB entry per role and copy button support
- test API for returning last TTPB entry

## Testing
- `./vendor/bin/pest`

------
https://chatgpt.com/codex/tasks/task_e_689d989d193483308802389e2c1eaab6